### PR TITLE
add @turboFrameSrc directive and deterministic redirect resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,7 +376,9 @@ return turbo_stream()
 
 ### Form Validation with Turbo Frames
 
-Extend `TurboFormRequest` to handle validation errors correctly within Turbo Frames. When validation fails, it redirects to the previous URL so the frame re-renders with errors:
+Extend `TurboFormRequest` to handle validation errors correctly within Turbo Frames.
+When validation fails, the request redirects back to the page that rendered the frame
+so the frame re-renders with error messages.
 
 ```php
 use Emaia\LaravelHotwireTurbo\Http\Requests\TurboFormRequest;
@@ -392,6 +394,38 @@ class UpdateProfileRequest extends TurboFormRequest
     }
 }
 ```
+
+#### Explicit Frame Source URL
+
+Add the `@turboFrameSrc` directive inside your Turbo Frame forms for deterministic
+redirects that don't rely on session state or browser headers:
+
+```blade
+<turbo-frame id="profile-form" src="{{ route('profile.edit') }}">
+    <form method="POST" action="{{ route('profile.update') }}">
+        @turboFrameSrc
+
+        <input name="name" required />
+        <button>Save</button>
+    </form>
+</turbo-frame>
+```
+
+This renders a hidden input with the current page URL, ensuring the redirect
+target is always correct — even with lazy-loaded frames or multiple browser tabs.
+
+#### Redirect Source Priority
+
+When validation fails inside a Turbo Frame, the redirect URL is resolved in this order:
+
+| Priority | Source | Notes |
+|---|---|---|
+| 1 | `_turbo_frame_src` input | Set by `@turboFrameSrc` — deterministic, server-side |
+| 2 | `X-Turbo-Frame-Src` header | Optional, can be set by client-side JS if desired |
+| 3 | `Referer` header | Browser native |
+| 4 | `url()->previous()` | Laravel session fallback |
+
+External URLs are rejected (redirects fall back to `/`) to prevent open redirect attacks.
 
 ### Blade Components
 

--- a/src/Http/Requests/TurboFormRequest.php
+++ b/src/Http/Requests/TurboFormRequest.php
@@ -10,9 +10,31 @@ class TurboFormRequest extends FormRequest
     protected function failedValidation(Validator $validator): void
     {
         if (request()->wasFromTurboFrame()) {
-            $this->redirect = url(session('_previous.url'));
+            $this->redirect = $this->resolveFrameSourceUrl();
         }
 
         parent::failedValidation($validator);
+    }
+
+    private function resolveFrameSourceUrl(): string
+    {
+        return $this->sanitizeRedirectUrl(
+            $this->input('_turbo_frame_src')
+                ?: $this->header('X-Turbo-Frame-Src')
+                ?: $this->header('Referer')
+                ?: url()->previous()
+        );
+    }
+
+    private function sanitizeRedirectUrl(string $url): string
+    {
+        $appHost = parse_url(config('app.url'), PHP_URL_HOST);
+        $host = parse_url($url, PHP_URL_HOST);
+
+        if ($host === null || $host === $appHost) {
+            return $url;
+        }
+
+        return url('/');
     }
 }

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -79,6 +79,10 @@ class TurboServiceProvider extends PackageServiceProvider
             return '<meta name="turbo-cache-control" content="no-preview">';
         });
 
+        Blade::directive('turboFrameSrc', function () {
+            return "<?php echo '<input type=\"hidden\" name=\"_turbo_frame_src\" value=\"'.e(url()->full()).'\">'; ?>";
+        });
+
         Blade::directive('turboRefreshMethod', function (string $method) {
             return "<?php echo '<meta name=\"turbo-refresh-method\" content=\"'.e({$method}).'\">' ?>";
         });

--- a/tests/TurboFormRequestTest.php
+++ b/tests/TurboFormRequestTest.php
@@ -1,0 +1,73 @@
+<?php
+
+use Emaia\LaravelHotwireTurbo\Http\Requests\TurboFormRequest;
+use Emaia\LaravelHotwireTurbo\Testing\InteractsWithTurbo;
+use Illuminate\Support\Facades\Route;
+
+uses(InteractsWithTurbo::class);
+
+class ProfileUpdateRequest extends TurboFormRequest
+{
+    public function rules(): array
+    {
+        return ['name' => 'required'];
+    }
+}
+
+beforeEach(function () {
+    Route::post('/profile', function (ProfileUpdateRequest $request) {
+        // Validation failed, never reached
+    });
+});
+
+it('redirects to _turbo_frame_src input when present in turbo frame request', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->post('/profile', [
+            'name' => '',
+            '_turbo_frame_src' => url('/profile'),
+        ]);
+
+    $response->assertRedirect('/profile');
+});
+
+it('falls back to Referer header when _turbo_frame_src is absent', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->post('/profile', ['name' => ''], ['Referer' => url('/dashboard')]);
+
+    $response->assertRedirect('/dashboard');
+});
+
+it('falls back to url()->previous() when no input or referer', function () {
+    session()->setPreviousUrl(url('/fallback'));
+
+    $response = $this->fromTurboFrame('profile-form')
+        ->post('/profile', ['name' => '']);
+
+    $response->assertRedirect('/fallback');
+});
+
+it('accepts relative URL in _turbo_frame_src', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->post('/profile', [
+            'name' => '',
+            '_turbo_frame_src' => '/profile?tab=settings',
+        ]);
+
+    $response->assertRedirect('/profile?tab=settings');
+});
+
+it('rejects external URL in _turbo_frame_src to prevent open redirect', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->post('/profile', [
+            'name' => '',
+            '_turbo_frame_src' => 'https://evil.com/phishing',
+        ]);
+
+    $response->assertRedirect('/');
+});
+
+it('does not alter redirect for non-turbo-frame requests', function () {
+    $response = $this->post('/profile', ['name' => '']);
+
+    $response->assertRedirect('/');
+});


### PR DESCRIPTION
- New Blade directive @turboFrameSrc renders a hidden input with url()->full() for explicit frame source tracking                                                                                                                                                                                  
- TurboFormRequest now uses a 4-level priority chain to resolve the redirect URL on validation failure:                                                                                                                                                                                           
       1. _turbo_frame_src input (server-side, deterministic)                                                                                                                                                                            
       2. X-Turbo-Frame-Src header (future Stimulus integration)                                                                                                                                                                         
       3. Referer header (browser fallback)                                                                                                                                                                                              
       4. url()->previous() (session, last resort)                                                                                                                                                                                       
- External URLs are rejected (redirect to /) to prevent open redirect                                                                                                                                                               
- Tests cover all 5 scenarios (input, Referer, session, external, non-turbo) 

### Problem

`TurboFormRequest::failedValidation()` used `session('_previous.url')` to determine the redirect URL on validation failure. This is fragile:

- Session can be stale after lazy frame loads
- Breaks with multiple browser tabs
- Not deterministic

### Solution

**New `@turboFrameSrc` Blade directive** — renders a hidden input with the current page URL:

```blade
<form method="POST" action="/profile">
    @turboFrameSrc                                                                                                                                                                             
    <input name="email" required />
    <button>Save</button>
</form>
```