### PR TITLE
Configure auto-generated release notes by category

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,37 @@
+# Configures the auto-generated release notes used by GitHub's
+# "Generate release notes" button. The body of a published release
+# is then consumed by the update-changelog workflow, so categories
+# here become the section headers in CHANGELOG.md.
+#
+# Keep the category titles aligned with Keep a Changelog
+# (https://keepachangelog.com) so the changelog stays consistent
+# with the manually-written entries in earlier versions.
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - wontfix
+      - question
+  categories:
+    - title: Added
+      labels:
+        - enhancement
+    - title: Changed
+      labels:
+        - refactor
+        - change
+    - title: Fixed
+      labels:
+        - bug
+    - title: Removed
+      labels:
+        - removal
+        - breaking
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Other Changes
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- Adds `.github/release.yml` so GitHub's "Generate release notes" produces sections following Keep a Changelog (Added / Changed / Fixed / Removed / Documentation).
- Body of the published release feeds into `update-changelog.yml` → CHANGELOG.md stays consistent with prior manual entries.

## Notes
- Some referenced labels do not yet exist (`refactor`, `change`, `removal`, `breaking`); they can be created as a follow-up. The config is forward-compatible — unknown labels are simply ignored.

## Test plan
- [x] After merge, draft a test release; verify "Generate release notes" produces categorized sections.