### PR TITLE
Make streams echoable in Blade via Htmlable; expose Stream::macro()

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ The purpose of this package is to facilitate the use of [Turbo](https://turbo.ho
     - [Targeting Multiple Elements (CSS Selectors)](#targeting-multiple-elements-css-selectors)
     - [Conditional Chaining](#conditional-chaining)
     - [Custom Macros](#custom-macros)
+    - [Echoing Streams in Blade](#echoing-streams-in-blade)
   - [DOM Identification](#dom-identification)
   - [Creating Individual Streams](#creating-individual-streams)
   - [Targeting Multiple Elements](#targeting-multiple-elements-css-selector)
@@ -136,9 +137,10 @@ turbo_stream()
 
 #### Custom Macros
 
-The builder uses Laravel's `Macroable` trait, so you can register your own methods to encapsulate repetitive stream patterns. Register macros in your `AppServiceProvider`:
+Both `TurboStreamBuilder` and `Stream` use Laravel's `Macroable` trait, so you can register your own methods to encapsulate repetitive stream patterns. Register macros in your `AppServiceProvider`:
 
 ```php
+use Emaia\LaravelHotwireTurbo\Stream;
 use Emaia\LaravelHotwireTurbo\TurboStreamBuilder;
 use Illuminate\Support\Facades\Blade;
 
@@ -154,6 +156,11 @@ TurboStreamBuilder::macro('flash', function (string $type, string $message) {
         compact('type', 'message')
     ));
 });
+
+// Macros also work on the Stream factory for one-off streams.
+Stream::macro('confetti', function (string $target) {
+    return Stream::action('confetti', $target, '', ['data-duration' => '2000']);
+});
 ```
 
 Then use them fluently in your controllers:
@@ -163,7 +170,21 @@ return turbo_stream()
     ->replace($message, view('messages._tr', compact('message')))
     ->flash('success', 'Updated successfully')
     ->closeModal();
+
+return response()->turboStream(Stream::confetti('party'));
 ```
+
+#### Echoing Streams in Blade
+
+`Stream`, `StreamCollection` and `TurboStreamBuilder` all implement `Htmlable`, so you can render them directly in Blade without escaping:
+
+```blade
+{{ turbo_stream()->append('messages', view('messages.item', compact('message'))) }}
+
+{{ Stream::remove($notification) }}
+```
+
+This is useful when composing Turbo Stream views by hand or returning streams from view composers.
 
 ### DOM Identification
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -4,13 +4,18 @@ namespace Emaia\LaravelHotwireTurbo;
 
 use Emaia\LaravelHotwireTurbo\Enums\Action;
 use Emaia\LaravelHotwireTurbo\Views\RecordIdentifier;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Traits\Macroable;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\View;
 use InvalidArgumentException;
+use Stringable;
 use Throwable;
 
-class Stream implements StreamInterface
+class Stream implements Htmlable, StreamInterface, Stringable
 {
+    use Macroable;
+
     /**
      * @param  array<string, string>  $attributes
      *
@@ -47,82 +52,129 @@ class Stream implements StreamInterface
 
     /**
      * @param  array<string, string>  $attributes
+     *
+     * @throws Throwable
      */
     public static function action(string $action, string|object $target, mixed $content = '', array $attributes = []): static
     {
         return new static($action, self::resolveTarget($target), $content, '', $attributes);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function append(string|object $target, mixed $content = ''): static
     {
         return new static(Action::APPEND, self::resolveTarget($target), $content);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function prepend(string|object $target, mixed $content = ''): static
     {
         return new static(Action::PREPEND, self::resolveTarget($target), $content);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function replace(string|object $target, mixed $content = '', ?string $method = null): static
     {
         return new static(Action::REPLACE, self::resolveTarget($target), $content, attributes: array_filter(['method' => $method]));
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function update(string|object $target, mixed $content = '', ?string $method = null): static
     {
         return new static(Action::UPDATE, self::resolveTarget($target), $content, attributes: array_filter(['method' => $method]));
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function remove(string|object $target): static
     {
         return new static(Action::REMOVE, self::resolveTarget($target));
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function after(string|object $target, mixed $content = ''): static
     {
         return new static(Action::AFTER, self::resolveTarget($target), $content);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function before(string|object $target, mixed $content = ''): static
     {
         return new static(Action::BEFORE, self::resolveTarget($target), $content);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function appendAll(string $targets, mixed $content = ''): static
     {
         return new static(Action::APPEND, content: $content, targets: $targets);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function prependAll(string $targets, mixed $content = ''): static
     {
         return new static(Action::PREPEND, content: $content, targets: $targets);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function replaceAll(string $targets, mixed $content = '', ?string $method = null): static
     {
         return new static(Action::REPLACE, content: $content, targets: $targets, attributes: array_filter(['method' => $method]));
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function updateAll(string $targets, mixed $content = '', ?string $method = null): static
     {
         return new static(Action::UPDATE, content: $content, targets: $targets, attributes: array_filter(['method' => $method]));
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function removeAll(string $targets): static
     {
         return new static(Action::REMOVE, targets: $targets);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function afterAll(string $targets, mixed $content = ''): static
     {
         return new static(Action::AFTER, content: $content, targets: $targets);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function beforeAll(string $targets, mixed $content = ''): static
     {
         return new static(Action::BEFORE, content: $content, targets: $targets);
     }
 
+    /**
+     * @throws Throwable
+     */
     public static function refresh(?string $method = null, ?string $scroll = null, ?string $requestId = null): static
     {
         return new static(Action::REFRESH, attributes: array_filter([
@@ -158,5 +210,21 @@ class Stream implements StreamInterface
             ),
             ...$viewProps,
         ])->render();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function toHtml(): string
+    {
+        return $this->render();
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/src/StreamCollection.php
+++ b/src/StreamCollection.php
@@ -2,9 +2,11 @@
 
 namespace Emaia\LaravelHotwireTurbo;
 
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
+use Stringable;
 
-class StreamCollection extends Collection implements StreamInterface
+class StreamCollection extends Collection implements Htmlable, StreamInterface, Stringable
 {
     public function __construct($items = [])
     {
@@ -38,5 +40,15 @@ class StreamCollection extends Collection implements StreamInterface
     public static function make($items = [], ...$args): static
     {
         return new static($items);
+    }
+
+    public function toHtml(): string
+    {
+        return $this->render();
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/src/TurboStreamBuilder.php
+++ b/src/TurboStreamBuilder.php
@@ -3,11 +3,13 @@
 namespace Emaia\LaravelHotwireTurbo;
 
 use Emaia\LaravelHotwireTurbo\Response as TurboResponse;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Support\Traits\Conditionable;
 use Illuminate\Support\Traits\Macroable;
+use Stringable;
 
-class TurboStreamBuilder implements Responsable, StreamInterface
+class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stringable
 {
     use Conditionable, Macroable;
 
@@ -146,5 +148,15 @@ class TurboStreamBuilder implements Responsable, StreamInterface
     public function toResponse($request): TurboResponse
     {
         return $this->withResponse();
+    }
+
+    public function toHtml(): string
+    {
+        return $this->render();
+    }
+
+    public function __toString(): string
+    {
+        return $this->render();
     }
 }

--- a/tests/StreamCollectionTest.php
+++ b/tests/StreamCollectionTest.php
@@ -3,6 +3,9 @@
 use Emaia\LaravelHotwireTurbo\Enums\Action;
 use Emaia\LaravelHotwireTurbo\Stream;
 use Emaia\LaravelHotwireTurbo\StreamCollection;
+use Emaia\LaravelHotwireTurbo\StreamInterface;
+use Illuminate\Contracts\Support\Htmlable;
+use Illuminate\Support\Facades\Blade;
 
 it('renders multiple streams', function () {
     $collection = new StreamCollection([
@@ -26,8 +29,8 @@ it('supports add method', function () {
         ->add(Stream::append('list', '<li>One</li>'))
         ->add(Stream::prepend('list', '<li>Zero</li>'));
 
-    expect($collection)->toHaveCount(2);
-    expect($collection->render())
+    expect($collection)->toHaveCount(2)
+        ->and($collection->render())
         ->toContain('action="append"')
         ->toContain('action="prepend"');
 });
@@ -39,6 +42,49 @@ it('throws exception when adding non-stream via add', function () {
 it('creates empty collection with make', function () {
     $collection = StreamCollection::make();
 
-    expect($collection)->toHaveCount(0);
-    expect($collection->render())->toBe('');
+    expect($collection)->toHaveCount(0)
+        ->and($collection->render())->toBe('');
+});
+
+describe('renderable contracts', function () {
+    it('implements Htmlable, StreamInterface and Stringable', function () {
+        $collection = StreamCollection::make()
+            ->add(Stream::append('list', '<li>One</li>'));
+
+        expect($collection)
+            ->toBeInstanceOf(Htmlable::class)
+            ->toBeInstanceOf(StreamInterface::class)
+            ->toBeInstanceOf(Stringable::class);
+    });
+
+    it('returns the rendered html string from toHtml()', function () {
+        $collection = StreamCollection::make()
+            ->add(Stream::append('list', '<li>One</li>'));
+
+        expect($collection->toHtml())
+            ->toBeString()
+            ->toContain('action="append"');
+    });
+
+    it('renders to string when echoed', function () {
+        $collection = StreamCollection::make()
+            ->add(Stream::append('list', '<li>One</li>'))
+            ->add(Stream::remove('modal'));
+
+        expect((string) $collection)
+            ->toContain('action="append"')
+            ->toContain('action="remove"');
+    });
+
+    it('can be echoed in Blade without escaping the turbo-stream tags', function () {
+        $collection = StreamCollection::make()
+            ->add(Stream::append('list', '<li>One</li>'));
+
+        $html = Blade::render('{{ $streams }}', ['streams' => $collection]);
+
+        expect($html)
+            ->toContain('<turbo-stream')
+            ->toContain('action="append"')
+            ->not->toContain('&lt;turbo-stream');
+    });
 });

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -2,6 +2,8 @@
 
 use Emaia\LaravelHotwireTurbo\Enums\Action;
 use Emaia\LaravelHotwireTurbo\Stream;
+use Emaia\LaravelHotwireTurbo\StreamInterface;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Blade;
 
@@ -245,6 +247,70 @@ describe('model-aware targets', function () {
         $html = Stream::append('my-target', 'content')->render();
 
         expect($html)->toContain('target="my-target"');
+    });
+});
+
+describe('renderable contracts', function () {
+    it('implements Htmlable, StreamInterface and Stringable', function () {
+        $stream = Stream::append('messages', '<p>Hi</p>');
+
+        expect($stream)
+            ->toBeInstanceOf(Htmlable::class)
+            ->toBeInstanceOf(StreamInterface::class)
+            ->toBeInstanceOf(Stringable::class);
+    });
+
+    it('returns the rendered html string from toHtml()', function () {
+        $stream = Stream::append('messages', '<p>Hi</p>');
+
+        expect($stream->toHtml())
+            ->toBeString()
+            ->toContain('action="append"')
+            ->toContain('target="messages"');
+    });
+
+    it('renders to string when echoed', function () {
+        $stream = Stream::append('messages', '<p>Hi</p>');
+
+        expect((string) $stream)->toContain('action="append"');
+    });
+
+    it('can be echoed in Blade without escaping the turbo-stream tag', function () {
+        $stream = Stream::append('messages', '<p>Hi</p>');
+
+        $html = Blade::render('{{ $stream }}', ['stream' => $stream]);
+
+        expect($html)
+            ->toContain('<turbo-stream')
+            ->toContain('action="append"')
+            ->not->toContain('&lt;turbo-stream');
+    });
+});
+
+describe('Stream::macro', function () {
+    it('registers and invokes a custom factory macro', function () {
+        Stream::macro('confetti', function (string $target) {
+            return Stream::action('confetti', $target, '', ['data-duration' => '2000']);
+        });
+
+        $stream = Stream::confetti('party');
+
+        expect($stream)->toBeInstanceOf(Stream::class);
+        expect($stream->render())
+            ->toContain('action="confetti"')
+            ->toContain('target="party"')
+            ->toContain('data-duration="2000"');
+    });
+
+    it('supports macros invoked on instances', function () {
+        Stream::macro('withDebugAttribute', function () {
+            /** @var Stream $this */
+            return $this;
+        });
+
+        $stream = Stream::append('messages', '<p>Hi</p>')->withDebugAttribute();
+
+        expect($stream)->toBeInstanceOf(Stream::class);
     });
 });
 

--- a/tests/TurboStreamBuilderTest.php
+++ b/tests/TurboStreamBuilderTest.php
@@ -3,8 +3,10 @@
 use Emaia\LaravelHotwireTurbo\Response;
 use Emaia\LaravelHotwireTurbo\StreamInterface;
 use Emaia\LaravelHotwireTurbo\TurboStreamBuilder;
+use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\Facades\Route;
 
 class BuilderTestMessage extends Model
@@ -296,4 +298,43 @@ it('can be returned directly as a response', function () {
 
     expect($response->headers->get('Content-Type'))->toContain('text/vnd.turbo-stream.html')
         ->and($response->getContent())->toContain('action="append"');
+});
+
+describe('renderable contracts', function () {
+    it('implements Htmlable, Responsable, StreamInterface and Stringable', function () {
+        $builder = turbo_stream()->append('messages', '<p>Hi</p>');
+
+        expect($builder)
+            ->toBeInstanceOf(Htmlable::class)
+            ->toBeInstanceOf(Responsable::class)
+            ->toBeInstanceOf(StreamInterface::class)
+            ->toBeInstanceOf(Stringable::class);
+    });
+
+    it('returns the rendered html string from toHtml()', function () {
+        $builder = turbo_stream()->append('messages', '<p>Hi</p>');
+
+        expect($builder->toHtml())
+            ->toBeString()
+            ->toContain('action="append"');
+    });
+
+    it('renders to string when echoed', function () {
+        $builder = turbo_stream()->append('messages', '<p>Hi</p>')->remove('modal');
+
+        expect((string) $builder)
+            ->toContain('action="append"')
+            ->toContain('action="remove"');
+    });
+
+    it('can be echoed in Blade without escaping the turbo-stream tags', function () {
+        $builder = turbo_stream()->append('messages', '<p>Hi</p>');
+
+        $html = Blade::render('{{ $stream }}', ['stream' => $builder]);
+
+        expect($html)
+            ->toContain('<turbo-stream')
+            ->toContain('action="append"')
+            ->not->toContain('&lt;turbo-stream');
+    });
 });


### PR DESCRIPTION
## Summary
- `Stream`, `StreamCollection` and `TurboStreamBuilder` now implement `Htmlable` and `Stringable`, so they can be echoed directly in Blade (`{{ $stream }}`) without HTML escaping.
- `Stream` now uses the `Macroable` trait alongside the existing `TurboStreamBuilder` macros, so custom factory methods can be registered on the `Stream` class as well.

## Notes
- Intentionally **not** implementing `Illuminate\Contracts\Support\Renderable`. `View::gatherData()` would convert any `Renderable` to its string form before the view runs, which would defeat the purpose by causing `e()` to escape the resulting HTML. Implementing `Htmlable` is the correct path here.
- Backwards compatible: no method signatures changed, only new methods/contracts added.

## Test plan
- [x] `vendor/bin/pest` — 177 passed (338 assertions)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/pint --test` — passed
- [x] Manual smoke: echo `{{ turbo_stream()->append(...) }}` in a Blade view; HTML renders unescaped.