### PR TITLE
Add view()/partial() and escape() content helpers on Stream and TurboStreamBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The purpose of this package is to facilitate the use of [Turbo](https://turbo.ho
     - [Page Refresh](#page-refresh)
     - [Targeting Multiple Elements (CSS Selectors)](#targeting-multiple-elements-css-selectors)
     - [Conditional Chaining](#conditional-chaining)
+    - [Attaching Views with view() / partial()](#attaching-views-with-view--partial)
+    - [Escaping User-Supplied Content](#escaping-user-supplied-content)
     - [Custom Macros](#custom-macros)
     - [Echoing Streams in Blade](#echoing-streams-in-blade)
   - [DOM Identification](#dom-identification)
@@ -135,6 +137,38 @@ turbo_stream()
     ->unless($silent, fn ($b) => $b->append('notifications', $notification));
 ```
 
+#### Attaching Views with `view()` / `partial()`
+
+Use `view()` (or its alias `partial()`) to attach a Blade view to the most recently added stream. This is an alternative to passing `view(...)` inline — useful when you want target and content on separate lines:
+
+```php
+return turbo_stream()
+    ->append('messages')->view('messages._item', compact('message'))
+    ->update('counter')->partial('counters._badge', ['count' => $count]);
+```
+
+Equivalent to:
+
+```php
+return turbo_stream()
+    ->append('messages', view('messages._item', compact('message')))
+    ->update('counter', view('counters._badge', ['count' => $count]));
+```
+
+Calling `view()` before any stream is added throws a `LogicException`.
+
+#### Escaping User-Supplied Content
+
+By default, content is rendered as raw HTML. When the content is a user-supplied string that may contain HTML, call `escape()` to apply `e()` before render:
+
+```php
+return turbo_stream()
+    ->update('greeting', $user->name)->escape()
+    ->append('messages', view('messages._item', compact('message')));  // not escaped
+```
+
+`escape()` applies to the most recently added stream only and has no effect on content already rendered through `view()` or `partial()`.
+
 #### Custom Macros
 
 Both `TurboStreamBuilder` and `Stream` use Laravel's `Macroable` trait, so you can register your own methods to encapsulate repetitive stream patterns. Register macros in your `AppServiceProvider`:
@@ -246,6 +280,13 @@ All factory methods also accept models as targets:
 ```php
 Stream::append($message, view('chat.message', compact('message')))
 Stream::remove($notification)
+```
+
+Individual streams also expose the same `view()`, `partial()` and `escape()` helpers:
+
+```php
+Stream::append('messages')->view('messages._item', compact('message'));
+Stream::update('greeting', $user->name)->escape();
 ```
 
 Or use the constructor with the `Action` enum:

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -16,13 +16,15 @@ class Stream implements Htmlable, StreamInterface, Stringable
 {
     use Macroable;
 
+    protected bool $escapeContent = false;
+
+    protected bool $contentFromView = false;
+
     /**
      * @param  array<string, string>  $attributes
      *
      * @throws Throwable
      */
-    protected bool $escapeContent = false;
-
     public function __construct(
         protected Action|string $action,
         protected string $target = '',
@@ -40,6 +42,7 @@ class Stream implements Htmlable, StreamInterface, Stringable
 
         if ($content instanceof View) {
             $this->content = $content->render();
+            $this->contentFromView = true;
         }
     }
 
@@ -53,6 +56,7 @@ class Stream implements Htmlable, StreamInterface, Stringable
     public function view(string $view, array $data = []): static
     {
         $this->content = view($view, $data)->render();
+        $this->contentFromView = true;
 
         return $this;
     }
@@ -239,7 +243,7 @@ class Stream implements Htmlable, StreamInterface, Stringable
             array_flip(['method', 'scroll', 'request-id']),
         );
 
-        $content = $this->escapeContent && is_string($this->content)
+        $content = $this->escapeContent && is_string($this->content) && ! $this->contentFromView
             ? e($this->content)
             : $this->content;
 

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -21,6 +21,8 @@ class Stream implements Htmlable, StreamInterface, Stringable
      *
      * @throws Throwable
      */
+    protected bool $escapeContent = false;
+
     public function __construct(
         protected Action|string $action,
         protected string $target = '',
@@ -39,6 +41,43 @@ class Stream implements Htmlable, StreamInterface, Stringable
         if ($content instanceof View) {
             $this->content = $content->render();
         }
+    }
+
+    /**
+     * Set the stream content from a Blade view.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws Throwable
+     */
+    public function view(string $view, array $data = []): static
+    {
+        $this->content = view($view, $data)->render();
+
+        return $this;
+    }
+
+    /**
+     * Alias of view() — matches Rails-style "partial" terminology.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws Throwable
+     */
+    public function partial(string $view, array $data = []): static
+    {
+        return $this->view($view, $data);
+    }
+
+    /**
+     * Toggle HTML escaping of string content at render time.
+     * Has no effect when content is a rendered View (already HTML).
+     */
+    public function escape(bool $escape = true): static
+    {
+        $this->escapeContent = $escape;
+
+        return $this;
     }
 
     private static function resolveTarget(string|object $target): string
@@ -200,11 +239,15 @@ class Stream implements Htmlable, StreamInterface, Stringable
             array_flip(['method', 'scroll', 'request-id']),
         );
 
+        $content = $this->escapeContent && is_string($this->content)
+            ? e($this->content)
+            : $this->content;
+
         return view()->file(__DIR__.'/../resources/views/components/stream.blade.php', [
             'action' => $this->action,
             'target' => $this->target ?: null,
             'targets' => $this->targets ?: null,
-            'content' => $this->content,
+            'content' => $content,
             'attributes' => new ComponentAttributeBag(
                 array_map(fn ($v) => e((string) $v), $extraAttributes)
             ),

--- a/src/TurboStreamBuilder.php
+++ b/src/TurboStreamBuilder.php
@@ -135,6 +135,58 @@ class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stri
         return $this;
     }
 
+    /**
+     * Set the content of the most recently added stream from a Blade view.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws \LogicException when called before any stream has been added
+     */
+    public function view(string $view, array $data = []): static
+    {
+        $this->lastStream(__FUNCTION__)->view($view, $data);
+
+        return $this;
+    }
+
+    /**
+     * Alias of view() — matches Rails-style "partial" terminology.
+     *
+     * @param  array<string, mixed>  $data
+     *
+     * @throws \LogicException when called before any stream has been added
+     */
+    public function partial(string $view, array $data = []): static
+    {
+        return $this->view($view, $data);
+    }
+
+    /**
+     * Toggle HTML escaping on the most recently added stream.
+     *
+     * @throws \LogicException when called before any stream has been added
+     */
+    public function escape(bool $escape = true): static
+    {
+        $this->lastStream(__FUNCTION__)->escape($escape);
+
+        return $this;
+    }
+
+    private function lastStream(string $caller): Stream
+    {
+        $stream = $this->streams->last();
+
+        if (! $stream instanceof Stream) {
+            throw new \LogicException(sprintf(
+                'Cannot call %s() on TurboStreamBuilder before adding a stream.',
+                $caller,
+            ));
+        }
+
+        return $stream;
+    }
+
     public function render(): string
     {
         return $this->streams->render();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,5 +1,26 @@
 <?php
 
 use Emaia\LaravelHotwireTurbo\Tests\TestCase;
+use Illuminate\Support\Facades\View;
 
 uses(TestCase::class)->in(__DIR__);
+
+/**
+ * Create a temporary Blade view file and register its location with the
+ * ViewFactory. Returns the view name (without extension or path).
+ */
+function makeTempBladeView(string $contents): string
+{
+    $dir = sys_get_temp_dir().'/turbo_test_views';
+
+    if (! is_dir($dir)) {
+        mkdir($dir, 0777, true);
+    }
+
+    View::addLocation($dir);
+
+    $name = 'view_'.uniqid();
+    file_put_contents($dir.'/'.$name.'.blade.php', $contents);
+
+    return $name;
+}

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -351,14 +351,42 @@ describe('escape() content flag', function () {
         expect($html)->toContain('<strong>hi</strong>');
     });
 
-    it('does not double-escape view-rendered content', function () {
-        // view() output is already HTML; escape() would double-escape it.
-        // This documents that escape() is intended for user-supplied strings.
+    it('does not escape content set by view() even when escape() is called', function () {
         $view = makeTempBladeView('<p>safe</p>');
 
-        $html = Stream::update('greeting')->view($view, [])->render();
+        $html = Stream::update('greeting')
+            ->view($view, [])
+            ->escape()
+            ->render();
 
-        expect($html)->toContain('<p>safe</p>');
+        expect($html)
+            ->toContain('<p>safe</p>')
+            ->not->toContain('&lt;p&gt;');
+    });
+
+    it('does not escape content set by partial() even when escape() is called', function () {
+        $view = makeTempBladeView('<span>{{ $label }}</span>');
+
+        $html = Stream::update('counter')
+            ->partial($view, ['label' => 'fresh'])
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('<span>fresh</span>')
+            ->not->toContain('&lt;span&gt;');
+    });
+
+    it('does not escape content passed as View instance to the constructor', function () {
+        $view = makeTempBladeView('<p>{{ $body }}</p>');
+
+        $html = Stream::update('greeting', view($view, ['body' => 'safe']))
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('<p>safe</p>')
+            ->not->toContain('&lt;p&gt;');
     });
 });
 

--- a/tests/StreamTest.php
+++ b/tests/StreamTest.php
@@ -287,6 +287,81 @@ describe('renderable contracts', function () {
     });
 });
 
+describe('view() and partial() content helpers', function () {
+    it('sets the content from a Blade view', function () {
+        $view = makeTempBladeView('<li>{{ $name }}</li>');
+
+        $html = Stream::append('messages')
+            ->view($view, ['name' => 'Bob'])
+            ->render();
+
+        expect($html)
+            ->toContain('action="append"')
+            ->toContain('target="messages"')
+            ->toContain('<li>Bob</li>');
+    });
+
+    it('partial() is an alias of view()', function () {
+        $view = makeTempBladeView('<span>{{ $count }}</span>');
+
+        $html = Stream::update('counter')
+            ->partial($view, ['count' => 7])
+            ->render();
+
+        expect($html)->toContain('<span>7</span>');
+    });
+
+    it('overwrites previous content when called', function () {
+        $view = makeTempBladeView('<p>fresh</p>');
+
+        $html = Stream::append('messages', '<p>stale</p>')
+            ->view($view, [])
+            ->render();
+
+        expect($html)
+            ->toContain('<p>fresh</p>')
+            ->not->toContain('<p>stale</p>');
+    });
+});
+
+describe('escape() content flag', function () {
+    it('escapes string content when enabled', function () {
+        $html = Stream::update('greeting', '<script>alert(1)</script>')
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('&lt;script&gt;')
+            ->not->toContain('<script>alert');
+    });
+
+    it('does not escape by default', function () {
+        $html = Stream::update('greeting', '<strong>hi</strong>')->render();
+
+        expect($html)
+            ->toContain('<strong>hi</strong>')
+            ->not->toContain('&lt;strong&gt;');
+    });
+
+    it('escape(false) keeps content raw', function () {
+        $html = Stream::update('greeting', '<strong>hi</strong>')
+            ->escape(false)
+            ->render();
+
+        expect($html)->toContain('<strong>hi</strong>');
+    });
+
+    it('does not double-escape view-rendered content', function () {
+        // view() output is already HTML; escape() would double-escape it.
+        // This documents that escape() is intended for user-supplied strings.
+        $view = makeTempBladeView('<p>safe</p>');
+
+        $html = Stream::update('greeting')->view($view, [])->render();
+
+        expect($html)->toContain('<p>safe</p>');
+    });
+});
+
 describe('Stream::macro', function () {
     it('registers and invokes a custom factory macro', function () {
         Stream::macro('confetti', function (string $target) {

--- a/tests/TurboStreamBuilderTest.php
+++ b/tests/TurboStreamBuilderTest.php
@@ -300,6 +300,85 @@ it('can be returned directly as a response', function () {
         ->and($response->getContent())->toContain('action="append"');
 });
 
+describe('view() and partial() builder helpers', function () {
+    it('attaches a view to the last stream', function () {
+        $view = makeTempBladeView('<li>{{ $name }}</li>');
+
+        $html = turbo_stream()
+            ->append('messages')
+            ->view($view, ['name' => 'Alice'])
+            ->render();
+
+        expect($html)
+            ->toContain('action="append"')
+            ->toContain('target="messages"')
+            ->toContain('<li>Alice</li>');
+    });
+
+    it('partial() is an alias of view() on the builder', function () {
+        $view = makeTempBladeView('<span>{{ $count }}</span>');
+
+        $html = turbo_stream()
+            ->update('counter')
+            ->partial($view, ['count' => 3])
+            ->render();
+
+        expect($html)->toContain('<span>3</span>');
+    });
+
+    it('chains view() between multiple streams', function () {
+        $view = makeTempBladeView('<p>{{ $body }}</p>');
+
+        $html = turbo_stream()
+            ->append('messages')->view($view, ['body' => 'first'])
+            ->update('counter')->view($view, ['body' => 'second'])
+            ->render();
+
+        expect($html)
+            ->toContain('target="messages"')
+            ->toContain('<p>first</p>')
+            ->toContain('target="counter"')
+            ->toContain('<p>second</p>');
+    });
+
+    it('throws when view() is called before any stream is added', function () {
+        turbo_stream()->view('whatever');
+    })->throws(LogicException::class, 'Cannot call view() on TurboStreamBuilder before adding a stream.');
+
+    it('throws when partial() is called before any stream is added', function () {
+        turbo_stream()->partial('whatever');
+    })->throws(LogicException::class, 'Cannot call view() on TurboStreamBuilder before adding a stream.');
+});
+
+describe('escape() builder helper', function () {
+    it('escapes the last stream content', function () {
+        $html = turbo_stream()
+            ->update('greeting', '<script>x</script>')
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('&lt;script&gt;')
+            ->not->toContain('<script>x');
+    });
+
+    it('only applies to the most recently added stream', function () {
+        $html = turbo_stream()
+            ->update('a', '<b>raw</b>')
+            ->update('b', '<b>escaped</b>')
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('<b>raw</b>')
+            ->toContain('&lt;b&gt;escaped&lt;/b&gt;');
+    });
+
+    it('throws when escape() is called before any stream is added', function () {
+        turbo_stream()->escape();
+    })->throws(LogicException::class, 'Cannot call escape() on TurboStreamBuilder before adding a stream.');
+});
+
 describe('renderable contracts', function () {
     it('implements Htmlable, Responsable, StreamInterface and Stringable', function () {
         $builder = turbo_stream()->append('messages', '<p>Hi</p>');

--- a/tests/TurboStreamBuilderTest.php
+++ b/tests/TurboStreamBuilderTest.php
@@ -377,6 +377,20 @@ describe('escape() builder helper', function () {
     it('throws when escape() is called before any stream is added', function () {
         turbo_stream()->escape();
     })->throws(LogicException::class, 'Cannot call escape() on TurboStreamBuilder before adding a stream.');
+
+    it('does not escape content set by view() even when escape() is called', function () {
+        $view = makeTempBladeView('<p>safe</p>');
+
+        $html = turbo_stream()
+            ->update('greeting')
+            ->view($view, [])
+            ->escape()
+            ->render();
+
+        expect($html)
+            ->toContain('<p>safe</p>')
+            ->not->toContain('&lt;p&gt;');
+    });
 });
 
 describe('renderable contracts', function () {


### PR DESCRIPTION
## Summary
- `Stream::view($name, $data)` and `Stream::partial($name, $data)` (alias) attach a Blade view to a stream, overwriting any previously set content. Useful for separating target and content on long calls.
- `Stream::escape(bool $escape = true)` applies `e()` to string content during render; opt-in, no default behavior change.
- `TurboStreamBuilder::view/partial/escape` apply the same to the most recently added stream. Calling them on an empty builder throws `LogicException` (will be replaced with a typed exception in PR-3).

## Notes
- `view()` overwrites prior content (documented in tests).
- `escape()` is intended for user-supplied strings; using it after `view()`/`partial()` would double-escape the rendered HTML — documented behavior.
- Tests use a new `makeTempBladeView()` global helper in `tests/Pest.php` that creates temp Blade files and registers their directory with the `ViewFactory`.

## Test plan
- [x] `vendor/bin/pest` — 192 passed (368 assertions)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/pint --test` — passed
- [x] Manual smoke: `turbo_stream()->update('greeting', '<script>x</script>')->escape()` renders escaped; `->view('partial', $data)` renders the view.