### PR TITLE
Introduce TurboStreamResponseFailedException for stream build failures (back-compat)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The purpose of this package is to facilitate the use of [Turbo](https://turbo.ho
     - [Turbo Stream Source](#turbo-stream-source)
   - [Turbo Drive Blade Directives](#turbo-drive-blade-directives)
   - [Turbo Drive Redirect 303](#turbo-drive-redirect-303)
+  - [Exceptions](#exceptions)
   - [Full Controller Example](#full-controller-example)
 - [Configuration](#configuration)
 - [Testing](#testing)
@@ -698,6 +699,24 @@ use Emaia\LaravelHotwireTurbo\Http\Middleware\TurboMiddleware;
 Route::middleware(TurboMiddleware::class)->group(function () {
     Route::post('/posts', [PostController::class, 'store']);
 });
+```
+
+### Exceptions
+
+When a Turbo Stream response cannot be built — missing target, non-stream item in a `StreamCollection`, or a builder method called before any stream was added — the package throws `Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException`.
+
+The exception extends `InvalidArgumentException` (and therefore `LogicException`), so existing catch blocks keep working. For finer-grained handling, catch the typed exception directly:
+
+```php
+use Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException;
+
+try {
+    return turbo_stream()->view('messages._item', compact('message'));
+} catch (TurboStreamResponseFailedException $e) {
+    // No stream was added before view(), missing target, etc.
+    report($e);
+    return back();
+}
 ```
 
 ### Full Controller Example

--- a/src/Exceptions/TurboStreamResponseFailedException.php
+++ b/src/Exceptions/TurboStreamResponseFailedException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Emaia\LaravelHotwireTurbo\Exceptions;
+
+use InvalidArgumentException;
+
+/**
+ * Thrown when a Turbo Stream response cannot be built — missing target,
+ * invalid collection item, or builder used out of order.
+ *
+ * Extends {@see InvalidArgumentException} so existing catch blocks keep working.
+ */
+class TurboStreamResponseFailedException extends InvalidArgumentException
+{
+    public static function missingTarget(): self
+    {
+        return new self('Either target or targets must be provided');
+    }
+
+    public static function builderEmpty(string $method): self
+    {
+        return new self(sprintf(
+            'Cannot call %s() on TurboStreamBuilder before adding a stream.',
+            $method,
+        ));
+    }
+
+    public static function nonStreamItem(): self
+    {
+        return new self('Collection items must be instances of Stream');
+    }
+}

--- a/src/Stream.php
+++ b/src/Stream.php
@@ -3,12 +3,12 @@
 namespace Emaia\LaravelHotwireTurbo;
 
 use Emaia\LaravelHotwireTurbo\Enums\Action;
+use Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException;
 use Emaia\LaravelHotwireTurbo\Views\RecordIdentifier;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Traits\Macroable;
 use Illuminate\View\ComponentAttributeBag;
 use Illuminate\View\View;
-use InvalidArgumentException;
 use Stringable;
 use Throwable;
 
@@ -37,7 +37,7 @@ class Stream implements Htmlable, StreamInterface, Stringable
             : $action;
 
         if ($this->action !== Action::REFRESH && empty($target) && empty($targets)) {
-            throw new InvalidArgumentException('Either target or targets must be provided');
+            throw TurboStreamResponseFailedException::missingTarget();
         }
 
         if ($content instanceof View) {

--- a/src/StreamCollection.php
+++ b/src/StreamCollection.php
@@ -2,6 +2,7 @@
 
 namespace Emaia\LaravelHotwireTurbo;
 
+use Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Support\Collection;
 use Stringable;
@@ -14,7 +15,7 @@ class StreamCollection extends Collection implements Htmlable, StreamInterface, 
 
         $this->each(function ($item) {
             if (! $item instanceof Stream) {
-                throw new \InvalidArgumentException('Collection items must be instances of Stream');
+                throw TurboStreamResponseFailedException::nonStreamItem();
             }
         });
     }
@@ -29,7 +30,7 @@ class StreamCollection extends Collection implements Htmlable, StreamInterface, 
     public function add($item): static
     {
         if (! $item instanceof Stream) {
-            throw new \InvalidArgumentException('Collection items must be instances of Stream');
+            throw TurboStreamResponseFailedException::nonStreamItem();
         }
 
         $this->push($item);

--- a/src/TurboStreamBuilder.php
+++ b/src/TurboStreamBuilder.php
@@ -2,6 +2,7 @@
 
 namespace Emaia\LaravelHotwireTurbo;
 
+use Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException;
 use Emaia\LaravelHotwireTurbo\Response as TurboResponse;
 use Illuminate\Contracts\Support\Htmlable;
 use Illuminate\Contracts\Support\Responsable;
@@ -140,7 +141,7 @@ class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stri
      *
      * @param  array<string, mixed>  $data
      *
-     * @throws \LogicException when called before any stream has been added
+     * @throws TurboStreamResponseFailedException when called before any stream has been added
      */
     public function view(string $view, array $data = []): static
     {
@@ -154,7 +155,7 @@ class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stri
      *
      * @param  array<string, mixed>  $data
      *
-     * @throws \LogicException when called before any stream has been added
+     * @throws TurboStreamResponseFailedException when called before any stream has been added
      */
     public function partial(string $view, array $data = []): static
     {
@@ -164,7 +165,7 @@ class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stri
     /**
      * Toggle HTML escaping on the most recently added stream.
      *
-     * @throws \LogicException when called before any stream has been added
+     * @throws TurboStreamResponseFailedException when called before any stream has been added
      */
     public function escape(bool $escape = true): static
     {
@@ -178,10 +179,7 @@ class TurboStreamBuilder implements Htmlable, Responsable, StreamInterface, Stri
         $stream = $this->streams->last();
 
         if (! $stream instanceof Stream) {
-            throw new \LogicException(sprintf(
-                'Cannot call %s() on TurboStreamBuilder before adding a stream.',
-                $caller,
-            ));
+            throw TurboStreamResponseFailedException::builderEmpty($caller);
         }
 
         return $stream;

--- a/tests/TurboStreamResponseFailedExceptionTest.php
+++ b/tests/TurboStreamResponseFailedExceptionTest.php
@@ -1,0 +1,87 @@
+<?php
+
+use Emaia\LaravelHotwireTurbo\Enums\Action;
+use Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException;
+use Emaia\LaravelHotwireTurbo\Stream;
+use Emaia\LaravelHotwireTurbo\StreamCollection;
+
+describe('class hierarchy and back-compat', function () {
+    it('extends InvalidArgumentException', function () {
+        $exception = TurboStreamResponseFailedException::missingTarget();
+
+        expect($exception)
+            ->toBeInstanceOf(TurboStreamResponseFailedException::class)
+            ->toBeInstanceOf(InvalidArgumentException::class)
+            ->toBeInstanceOf(LogicException::class);
+    });
+});
+
+describe('named constructors', function () {
+    it('missingTarget() carries the expected message', function () {
+        $exception = TurboStreamResponseFailedException::missingTarget();
+
+        expect($exception->getMessage())->toBe('Either target or targets must be provided');
+    });
+
+    it('builderEmpty() interpolates the caller method name', function () {
+        $exception = TurboStreamResponseFailedException::builderEmpty('view');
+
+        expect($exception->getMessage())
+            ->toBe('Cannot call view() on TurboStreamBuilder before adding a stream.');
+    });
+
+    it('nonStreamItem() carries the expected message', function () {
+        $exception = TurboStreamResponseFailedException::nonStreamItem();
+
+        expect($exception->getMessage())->toBe('Collection items must be instances of Stream');
+    });
+});
+
+describe('integration: thrown from stream APIs', function () {
+    it('Stream constructor throws the typed exception when target is missing', function () {
+        try {
+            new Stream(Action::UPDATE, '', '');
+            $this->fail('Expected exception was not thrown.');
+        } catch (TurboStreamResponseFailedException $exception) {
+            expect($exception->getMessage())->toBe('Either target or targets must be provided');
+        }
+    });
+
+    it('TurboStreamBuilder::view() throws the typed exception when no stream was added', function () {
+        try {
+            turbo_stream()->view('whatever');
+            $this->fail('Expected exception was not thrown.');
+        } catch (TurboStreamResponseFailedException $exception) {
+            expect($exception->getMessage())
+                ->toBe('Cannot call view() on TurboStreamBuilder before adding a stream.');
+        }
+    });
+
+    it('TurboStreamBuilder::escape() throws the typed exception when no stream was added', function () {
+        try {
+            turbo_stream()->escape();
+            $this->fail('Expected exception was not thrown.');
+        } catch (TurboStreamResponseFailedException $exception) {
+            expect($exception->getMessage())
+                ->toBe('Cannot call escape() on TurboStreamBuilder before adding a stream.');
+        }
+    });
+
+    it('StreamCollection constructor throws the typed exception for non-stream items', function () {
+        try {
+            new StreamCollection(['not-a-stream']);
+            $this->fail('Expected exception was not thrown.');
+        } catch (TurboStreamResponseFailedException $exception) {
+            expect($exception->getMessage())->toBe('Collection items must be instances of Stream');
+        }
+    });
+
+    it('StreamCollection::add() throws the typed exception for non-stream items', function () {
+        try {
+            StreamCollection::make()->add('not-a-stream');
+            $this->fail('Expected exception was not thrown.');
+        } catch (TurboStreamResponseFailedException $exception) {
+            expect($exception->getMessage())->toBe('Collection items must be instances of Stream');
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `Emaia\LaravelHotwireTurbo\Exceptions\TurboStreamResponseFailedException` with three named constructors: `missingTarget()`, `builderEmpty(string $method)`, `nonStreamItem()`.
- Replaces the inline `InvalidArgumentException` / `LogicException` throws in `Stream`, `StreamCollection` and `TurboStreamBuilder` with the typed exception.

## Notes
- **Backwards compatible.** The new exception `extends InvalidArgumentException` (which itself extends `LogicException`), so existing catch blocks on either parent keep working. All previous 195 tests pass without modification.
- Error messages are unchanged — only the thrown class type is more specific.
- Unrelated exception sites (`RecordIdentifier`, `TurboFormRequest`) are intentionally not touched; they belong to other domains.

## Test plan
- [x] `vendor/bin/pest` — 204 passed (386 assertions), 9 new for the typed exception
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/pint --test` — passed
- [ ] Manual smoke: `catch (TurboStreamResponseFailedException $e)` catches the missing-target case; existing `catch (InvalidArgumentException $e)` still does.