### PR TITLE
Add <x-turbo::refreshes-with> component, turboRequestId() macro, and Model-aware frame :id

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ The purpose of this package is to facilitate the use of [Turbo](https://turbo.ho
     - [Turbo Frame](#turbo-frame)
     - [Turbo Stream Source](#turbo-stream-source)
   - [Turbo Drive Blade Directives](#turbo-drive-blade-directives)
+    - [Loading Turbo via CDN](#loading-turbo-via-cdn)
+    - [Meta Tag Directives](#meta-tag-directives)
+    - [Refreshes With](#refreshes-with)
   - [Turbo Drive Redirect 303](#turbo-drive-redirect-303)
   - [Exceptions](#exceptions)
   - [Full Controller Example](#full-controller-example)
@@ -395,6 +398,12 @@ if (request()->wasFromTurboFrame()) {
 if (request()->wasFromTurboFrame('modal')) {
     // ...
 }
+
+// Read the X-Turbo-Request-Id header (set by Turbo Drive on every visit).
+// Useful as a debounce key for refresh streams.
+$requestId = request()->turboRequestId();    // string|null
+
+return turbo_stream()->refresh(requestId: $requestId);
 ```
 
 ### Conditional Turbo Responses
@@ -594,13 +603,18 @@ Extra attributes are forwarded to the `<turbo-stream>` element (e.g. `data-contr
 
 {{-- Recursive frame --}}
 <x-turbo::frame id="recursive" src="/frame" recurse="composer" />
+
+{{-- Model-based id (resolves to dom_id($message)) --}}
+<x-turbo::frame :id="$message">
+    @include('messages._item', ['message' => $message])
+</x-turbo::frame>
 ```
 
 ##### Props reference
 
 | Prop | Description |
 |------|-------------|
-| `id` | Frame identifier (required) |
+| `id` | Frame identifier (required). Accepts a string or any object resolved via `dom_id()` (Eloquent model, DTO with `getKey()`/`$id`) |
 | `src` | URL to load content from (eager by default) |
 | `loading` | `eager` (default) or `lazy` |
 | `target` | Default navigation target — use `_top` to navigate the whole page |
@@ -678,6 +692,30 @@ Control Turbo Drive behavior in your layout's `<head>`:
 | `@turboRoot('/app')` | `<meta name="turbo-root" content="/app">` |
 | `@viewTransition('same-origin')` | `<meta name="view-transition" content="same-origin">` |
 | `@turboPrefetch('false')` | `<meta name="turbo-prefetch" content="false">` |
+
+#### Refreshes With
+
+`<x-turbo::refreshes-with>` packs the two most common page-refresh meta tags into a single component. Both props are optional — only the ones you pass are emitted:
+
+```blade
+<head>
+    <x-turbo::refreshes-with method="morph" scroll="preserve" />
+</head>
+```
+
+Outputs:
+
+```html
+<meta name="turbo-refresh-method" content="morph">
+<meta name="turbo-refresh-scroll" content="preserve">
+```
+
+| Prop | Description |
+|------|-------------|
+| `method` | `morph` — use morphing on page refreshes |
+| `scroll` | `preserve` or `reset` — scroll behavior |
+
+The individual directives (`@turboRefreshMethod`, `@turboRefreshScroll`) remain available if you prefer them.
 
 ### Turbo Drive Redirect 303
 

--- a/resources/views/components/frame.blade.php
+++ b/resources/views/components/frame.blade.php
@@ -13,6 +13,8 @@
 ])
 
 @php
+$resolvedId = is_object($id) ? dom_id($id) : $id;
+
 $mergeAttrs = array_filter([
     'src'                      => $src,
     'loading'                  => $loading,
@@ -26,4 +28,4 @@ $mergeAttrs = array_filter([
     'autoscroll'               => $autoscroll ? 'autoscroll' : null,
 ], fn ($v) => $v !== null);
 @endphp
-<turbo-frame id="{{ $id }}" {{ $attributes->merge($mergeAttrs) }}>{{ $slot }}</turbo-frame>
+<turbo-frame id="{{ $resolvedId }}" {{ $attributes->merge($mergeAttrs) }}>{{ $slot }}</turbo-frame>

--- a/resources/views/components/refreshes-with.blade.php
+++ b/resources/views/components/refreshes-with.blade.php
@@ -1,0 +1,9 @@
+@props([
+    'method' => null,
+    'scroll' => null,
+])
+
+@if ($method)<meta name="turbo-refresh-method" content="{{ $method }}">
+@endif
+@if ($scroll)<meta name="turbo-refresh-scroll" content="{{ $scroll }}">
+@endif

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -62,6 +62,10 @@ class TurboServiceProvider extends PackageServiceProvider
             return $this->header('Turbo-Frame', null) === $frame;
         });
 
+        Request::macro('turboRequestId', function (): ?string {
+            return $this->header('X-Turbo-Request-Id');
+        });
+
         Response::macro('turboStream', function (StreamInterface $content, $status = 200, array $headers = []) {
             return new TurboResponse($content, $status, $headers);
         });

--- a/tests/FrameComponentTest.php
+++ b/tests/FrameComponentTest.php
@@ -1,6 +1,14 @@
 <?php
 
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Blade;
+
+class FrameTestMessage extends Model
+{
+    protected $guarded = [];
+
+    protected $table = 'messages';
+}
 
 it('renders a basic turbo frame', function () {
     $html = Blade::render('<x-turbo::frame id="my-frame">Content</x-turbo::frame>');
@@ -98,4 +106,33 @@ it('does not emit omitted optional attributes', function () {
         ->not->toContain('recurse=')
         ->not->toContain('autoscroll')
         ->not->toContain('disabled');
+});
+
+describe('model-aware id', function () {
+    it('resolves an Eloquent model to its dom_id', function () {
+        $model = new FrameTestMessage;
+        $model->id = 7;
+
+        $html = Blade::render(
+            '<x-turbo::frame :id="$model">Hello</x-turbo::frame>',
+            ['model' => $model],
+        );
+
+        expect($html)->toContain('id="frame_test_message_7"');
+    });
+
+    it('resolves a new model with no key to its create prefix', function () {
+        $html = Blade::render(
+            '<x-turbo::frame :id="$model">Form</x-turbo::frame>',
+            ['model' => new FrameTestMessage],
+        );
+
+        expect($html)->toContain('id="create_frame_test_message"');
+    });
+
+    it('still accepts string ids', function () {
+        $html = Blade::render('<x-turbo::frame id="literal">Hi</x-turbo::frame>');
+
+        expect($html)->toContain('id="literal"');
+    });
 });

--- a/tests/RefreshesWithComponentTest.php
+++ b/tests/RefreshesWithComponentTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+it('emits both meta tags when method and scroll are provided', function () {
+    $html = Blade::render('<x-turbo::refreshes-with method="morph" scroll="preserve" />');
+
+    expect($html)
+        ->toContain('<meta name="turbo-refresh-method" content="morph">')
+        ->toContain('<meta name="turbo-refresh-scroll" content="preserve">');
+});
+
+it('emits only the method meta tag when scroll is omitted', function () {
+    $html = Blade::render('<x-turbo::refreshes-with method="morph" />');
+
+    expect($html)
+        ->toContain('<meta name="turbo-refresh-method" content="morph">')
+        ->not->toContain('turbo-refresh-scroll');
+});
+
+it('emits only the scroll meta tag when method is omitted', function () {
+    $html = Blade::render('<x-turbo::refreshes-with scroll="preserve" />');
+
+    expect($html)
+        ->toContain('<meta name="turbo-refresh-scroll" content="preserve">')
+        ->not->toContain('turbo-refresh-method');
+});
+
+it('emits nothing when both props are omitted', function () {
+    $html = Blade::render('<x-turbo::refreshes-with />');
+
+    expect(trim($html))->toBe('');
+});
+
+it('escapes user-supplied values in the content attribute', function () {
+    $html = Blade::render(
+        '<x-turbo::refreshes-with :method="$method" />',
+        ['method' => 'morph" data-injected="x'],
+    );
+
+    expect($html)
+        ->toContain('&quot;')
+        ->not->toContain('data-injected="x');
+});

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -38,3 +38,17 @@ it('returns false when no turbo frame header', function () {
 
     expect(request()->wasFromTurboFrame())->toBeFalse(); // @phpstan-ignore method.notFound
 });
+
+it('reads the turbo request id from the X-Turbo-Request-Id header', function () {
+    $this->call('GET', '/', [], [], [], [
+        'HTTP_X_TURBO_REQUEST_ID' => 'abc-123',
+    ]);
+
+    expect(request()->turboRequestId())->toBe('abc-123'); // @phpstan-ignore method.notFound
+});
+
+it('returns null when X-Turbo-Request-Id header is absent', function () {
+    $this->call('GET', '/');
+
+    expect(request()->turboRequestId())->toBeNull(); // @phpstan-ignore method.notFound
+});


### PR DESCRIPTION
## Summary
- New `<x-turbo::refreshes-with method="..." scroll="..." />` component packages the two most common page-refresh meta tags. Both props are optional — only the ones provided are emitted.
- New `request()->turboRequestId()` macro reads the `X-Turbo-Request-Id` header. Pairs with `Stream::refresh(requestId: ...)` for debouncing.
- `<x-turbo::frame :id>` now accepts Eloquent models / DTOs in addition to strings, resolving via `dom_id()` — matches the existing `Stream::append($model)` behavior.

## Notes
- Existing meta tag directives (`@turboRefreshMethod`, `@turboRefreshScroll`) remain available; the new component is sugar.
- Frame component falls back to string-id behavior when a string is passed — fully backwards compatible.

## Test plan
- [x] `vendor/bin/pest` — 214 passed (400 assertions)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/pint --test` — passed
- [x] Manual smoke: `<x-turbo::refreshes-with method="morph" />` renders one meta tag; `:id="$model"` resolves to `dom_id`.