### PR TITLE
Add assertTurboStreamCount/Has shortcuts and withoutTurbo() test helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -853,6 +853,10 @@ class MessageControllerTest extends TestCase
 // Send request with Turbo Stream Accept header
 $this->turbo()->post('/messages', ['body' => 'Hello']);
 
+// Send request as a plain (non-Turbo) browser visit — useful to assert
+// the same endpoint still returns full-page HTML.
+$this->withoutTurbo()->get('/messages')->assertSee('Inbox');
+
 // Send request from a specific Turbo Frame
 $this->fromTurboFrame('modal')->get('/messages/create');
 
@@ -868,7 +872,14 @@ $this->turbo()
     ->post('/messages', ['body' => 'Hello'])
     ->assertTurboStream();
 
-// Assert stream count and match specific streams
+// Shorthand assertions
+$this->turbo()
+    ->post('/messages', ['body' => 'Hello'])
+    ->assertTurboStreamCount(2)
+    ->assertTurboStreamHas('append', 'messages')
+    ->assertTurboStreamHas('append', 'messages', 'Hello');  // content optional
+
+// Or use the callback form for full control
 $this->turbo()
     ->delete("/messages/{$message->id}")
     ->assertTurboStream(fn ($streams) => $streams
@@ -879,13 +890,13 @@ $this->turbo()
         )
     );
 
-// Assert content inside a stream
+// Assert content inside a stream (callback form, when matching by `targets=` CSS selector)
 $this->turbo()
     ->post('/messages', ['body' => 'Hello'])
     ->assertTurboStream(fn ($streams) => $streams
         ->hasTurboStream(fn ($stream) => $stream
-            ->where('action', 'append')
-            ->where('target', 'messages')
+            ->where('action', 'update')
+            ->where('targets', '.badge')
             ->see('Hello')
         )
     );
@@ -893,6 +904,8 @@ $this->turbo()
 // Assert response is NOT a Turbo Stream
 $this->get('/messages')->assertNotTurboStream();
 ```
+
+The shorthand `assertTurboStreamHas` matches the `target` attribute (DOM id). For streams using CSS selectors (`targets=".css"`), use the callback form shown above.
 
 ## Running Tests
 

--- a/src/Testing/InteractsWithTurbo.php
+++ b/src/Testing/InteractsWithTurbo.php
@@ -14,6 +14,19 @@ trait InteractsWithTurbo
         return $this->withHeader('Accept', 'text/vnd.turbo-stream.html');
     }
 
+    /**
+     * Send requests as a plain (non-Turbo) browser visit. Clears any
+     * Turbo-Frame header previously set via fromTurboFrame() and sets
+     * Accept: text/html. Useful to assert that an endpoint still returns
+     * full-page HTML when accessed directly.
+     */
+    public function withoutTurbo(): static
+    {
+        unset($this->defaultHeaders['Turbo-Frame']);
+
+        return $this->withHeader('Accept', 'text/html');
+    }
+
     public function fromTurboFrame(string $frame): static
     {
         return $this->withHeader('Turbo-Frame', $frame);

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -164,5 +164,52 @@ class TurboServiceProvider extends PackageServiceProvider
 
             return $this;
         });
+
+        TestResponse::macro('assertTurboStreamCount', function (int $expected): TestResponse {
+            /** @var TestResponse $this */
+            $contentType = $this->headers->get('Content-Type', '');
+
+            Assert::assertStringContainsString(
+                'text/vnd.turbo-stream.html',
+                $contentType,
+                'Response Content-Type is not a Turbo Stream.',
+            );
+
+            $streams = ConvertTestResponseToTurboStreamCollection::convert($this);
+
+            Assert::assertCount(
+                $expected,
+                $streams,
+                sprintf('Expected %d turbo stream(s), found %d.', $expected, $streams->count()),
+            );
+
+            return $this;
+        });
+
+        TestResponse::macro('assertTurboStreamHas', function (string $action, string $target, ?string $content = null): TestResponse {
+            /** @var TestResponse $this */
+            $contentType = $this->headers->get('Content-Type', '');
+
+            Assert::assertStringContainsString(
+                'text/vnd.turbo-stream.html',
+                $contentType,
+                'Response Content-Type is not a Turbo Stream.',
+            );
+
+            $streams = ConvertTestResponseToTurboStreamCollection::convert($this);
+            $assertable = new AssertableTurboStream($streams);
+
+            $assertable->hasTurboStream(function ($matcher) use ($action, $target, $content) {
+                $matcher = $matcher->where('action', $action)->where('target', $target);
+
+                if ($content !== null) {
+                    $matcher = $matcher->see($content);
+                }
+
+                return $matcher;
+            });
+
+            return $this;
+        });
     }
 }

--- a/tests/Testing/AssertableTurboStreamTest.php
+++ b/tests/Testing/AssertableTurboStreamTest.php
@@ -4,6 +4,7 @@ use Emaia\LaravelHotwireTurbo\Testing\AssertableTurboStream;
 use Emaia\LaravelHotwireTurbo\Testing\ConvertTestResponseToTurboStreamCollection;
 use Emaia\LaravelHotwireTurbo\Testing\InteractsWithTurbo;
 use Illuminate\Support\Facades\Route;
+use PHPUnit\Framework\AssertionFailedError;
 
 uses(InteractsWithTurbo::class);
 
@@ -81,4 +82,106 @@ it('parses turbo streams from response', function () {
     $streams = ConvertTestResponseToTurboStreamCollection::convert($response);
 
     expect($streams)->toHaveCount(2);
+});
+
+describe('assertTurboStreamCount', function () {
+    it('passes when the count matches', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamCount(2);
+    });
+
+    it('fails when the count does not match', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamCount(5);
+    })->throws(AssertionFailedError::class, 'Expected 5 turbo stream(s), found 2.');
+
+    it('fails when response is not a Turbo Stream', function () {
+        $this->get('/normal-test')->assertTurboStreamCount(0);
+    })->throws(AssertionFailedError::class, 'Response Content-Type is not a Turbo Stream.');
+});
+
+describe('assertTurboStreamHas', function () {
+    it('passes when a matching stream is found', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamHas('append', 'messages')
+            ->assertTurboStreamHas('remove', 'modal');
+    });
+
+    it('passes when content matches inside the template', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamHas('append', 'messages', 'Hello');
+    });
+
+    it('fails when no stream matches action+target', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamHas('update', 'counter');
+    })->throws(AssertionFailedError::class, 'Expected to find a matching Turbo Stream');
+
+    it('fails when content does not appear in the matching stream', function () {
+        $this->turbo()
+            ->get('/turbo-test')
+            ->assertTurboStreamHas('append', 'messages', 'Missing-content-string');
+    })->throws(AssertionFailedError::class);
+
+    it('fails when response is not a Turbo Stream', function () {
+        $this->get('/normal-test')->assertTurboStreamHas('append', 'messages');
+    })->throws(AssertionFailedError::class, 'Response Content-Type is not a Turbo Stream.');
+});
+
+describe('withoutTurbo()', function () {
+    it('sends Accept: text/html, opting out of Turbo Stream responses', function () {
+        Route::get('/dual', function () {
+            if (request()->wantsTurboStream()) {
+                return turbo_stream()->append('messages', '<p>Turbo</p>')->withResponse();
+            }
+
+            return response('Plain page');
+        });
+
+        $this->withoutTurbo()
+            ->get('/dual')
+            ->assertOk()
+            ->assertSee('Plain page')
+            ->assertNotTurboStream();
+    });
+
+    it('overrides a prior turbo() call when chained', function () {
+        Route::get('/dual-chain', function () {
+            if (request()->wantsTurboStream()) {
+                return turbo_stream()->append('messages', '<p>Turbo</p>')->withResponse();
+            }
+
+            return response('Plain page');
+        });
+
+        $this->turbo()
+            ->withoutTurbo()
+            ->get('/dual-chain')
+            ->assertSee('Plain page')
+            ->assertNotTurboStream();
+    });
+
+    it('clears a Turbo-Frame header previously set by fromTurboFrame()', function () {
+        Route::get('/echo-frame', function () {
+            return response()->json([
+                'has_frame' => request()->wasFromTurboFrame(),
+                'frame' => request()->header('Turbo-Frame'),
+                'accept' => request()->header('Accept'),
+            ]);
+        });
+
+        $payload = $this->fromTurboFrame('modal')
+            ->withoutTurbo()
+            ->get('/echo-frame')
+            ->json();
+
+        expect($payload['has_frame'])->toBeFalse();
+        expect($payload['frame'])->toBeNull();
+        expect($payload['accept'])->toBe('text/html');
+    });
 });


### PR DESCRIPTION
## Summary
- New `TestResponse::assertTurboStreamCount(int $expected)` macro — direct assertion on stream count.
- New `TestResponse::assertTurboStreamHas(string $action, string $target, ?string $content = null)` macro — direct assertion that a stream with given action+target (and optional content) exists.
- New `InteractsWithTurbo::withoutTurbo()` method — clears any prior `Turbo-Frame` header and sends `Accept: text/html`. Useful to assert the same endpoint still returns full-page HTML for non-Turbo visits.

## Notes
- Both new assertions pre-check the response Content-Type and fail with a clear message when used on a non-Turbo-Stream response.
- `assertTurboStreamHas` matches the `target=` attribute (DOM id). For CSS-selector targets (`targets=".x"`), use the existing callback form documented in the README.
- `withoutTurbo()` removes the `Turbo-Frame` default header (set via `fromTurboFrame()`) before overriding `Accept`, so chaining `fromTurboFrame('modal')->withoutTurbo()` produces a genuinely Turbo-free request.

## Test plan
- [x] `vendor/bin/pest` — 225 passed (434 assertions)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `vendor/bin/pint --test` — passed
- [x] Manual smoke: chain `withoutTurbo()->get('/')` and confirm full-page HTML; chain `fromTurboFrame('modal')->withoutTurbo()` and confirm no `Turbo-Frame` header.