### PR TITLE
Expose validated Turbo Frame source URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,12 @@ if (request()->wasFromTurboFrame('modal')) {
     // ...
 }
 
+// Read the destination frame id without accessing the header directly.
+$frameId = request()->turboFrameId(); // "modal" or null
+
+// Read the explicit, redirect-safe hint for the frame contents URL.
+$source = request()->turboFrameSource(); // string|null
+
 // Read the X-Turbo-Request-Id header (set by Turbo Drive on every visit).
 // Useful as a debounce key for refresh streams.
 $requestId = request()->turboRequestId();    // string|null
@@ -496,25 +502,65 @@ redirects that don't rely on session state or browser headers:
 </turbo-frame>
 ```
 
-This renders a hidden input with the current page URL, ensuring the redirect
-target is always correct — even with lazy-loaded frames or multiple browser tabs.
+This renders a hidden input with the URL of the request that rendered the form.
+For a modal loaded from `/tasks/create`, that source is `/tasks/create`, even when
+the visible host page remains `/tasks`. This deterministic input does not depend
+on session state and takes precedence over the optional client-side header.
+
+URL fragments are preserved when an explicit candidate contains one. Browsers do
+not send fragments to the server, so `url()->full()` cannot reconstruct a fragment
+that was never part of the request.
+
+#### Reading the Explicit Frame Source
+
+Controllers and other request classes can reuse the same resolution policy:
+
+```php
+if ($source = $request->turboFrameSource()) {
+    return redirect()->to($source);
+}
+```
+
+`turboFrameSource()` returns the first valid `_turbo_frame_src` input or
+`X-Turbo-Frame-Src` header. It returns `null` outside Turbo Frame requests or when
+no explicit candidate is valid. It deliberately does not consult the session or
+`Referer`, so callers never mistake the host page for the frame source.
+
+Both explicit sources are client-controlled redirect hints. Validation makes them
+safe for this redirect policy, but does not prove which page rendered the frame and
+must never be used as an authorization signal. `turboFrameId()` trims a non-empty
+`Turbo-Frame` header and returns `null` for an absent or blank header;
+`wasFromTurboFrame()` uses the same strict semantics.
 
 #### Redirect Source Priority
 
 When validation fails inside a Turbo Frame, the redirect URL is resolved in this order:
 
-| Priority | Source                     | Notes                                                |
-|----------|----------------------------|------------------------------------------------------|
-| 1        | `_turbo_frame_src` input   | Set by `@turboFrameSrc` — deterministic, server-side |
-| 2        | `X-Turbo-Frame-Src` header | Optional, can be set by client-side JS if desired    |
-| 3        | `session('_previous.url')` | Laravel session fallback for simple cases            |
-| 4        | `RuntimeException`         | Explicit error when all sources fail                 |
+| Priority | Source                     | Public macro | Notes                                                |
+|----------|----------------------------|--------------|------------------------------------------------------|
+| 1        | `_turbo_frame_src` input   | Yes          | Set by `@turboFrameSrc` — deterministic, server-side |
+| 2        | `X-Turbo-Frame-Src` header | Yes          | Optional client-side fallback                        |
+| 3        | `session('_previous.url')` | No           | Internal `TurboFormRequest` compatibility fallback   |
+| 4        | `RuntimeException`         | No           | Explicit error when no safe source exists            |
 
-External URLs from levels 1 and 2 are validated against trusted hosts. Untrusted
-URLs are rejected (redirects fall back to `/`) to prevent open redirect attacks.
+Each candidate is validated before the next source is considered. An invalid input
+therefore does not block a valid header or session fallback. The session URL goes
+through the same sanitizer but remains excluded from `turboFrameSource()` because it
+may describe another tab, an intermediate navigation, or the host page.
 
-If no source URL can be resolved, a `RuntimeException` is thrown with a clear message
-asking the developer to add the `@turboFrameSrc` directive to the form.
+Root-relative paths and absolute HTTP(S) URLs on trusted hosts are accepted. Other
+schemes, protocol-relative URLs, malformed or browser-ambiguous authorities,
+userinfo, control characters, backslashes, and untrusted hosts are rejected. This
+is a trusted-host policy, not a strict same-origin policy:
+`trusted_redirect_hosts` intentionally compares hosts without treating scheme or
+port as trust boundaries.
+
+Well-formed percent-encoded path, query and fragment data is preserved as received;
+the resolver does not decode it before validating or returning the URL.
+
+If no safe source URL can be resolved, `TurboFormRequest` throws a `RuntimeException`
+asking the developer to add `@turboFrameSrc`. Invalid sources no longer redirect to
+`/`, because that response usually cannot repopulate the requesting frame.
 
 ### Blade Components
 
@@ -830,9 +876,10 @@ return [
     // Set to false to register the TurboMiddleware manually.
     'auto_redirect_303' => true,
 
-    // Extra hosts trusted for TurboFormRequest redirects. The current
-    // request host and APP_URL host are always trusted; anything else
-    // falls back to "/". Use for staging domains or reverse proxies.
+    // Extra hosts trusted for TurboFormRequest redirects. Only root-relative
+    // paths and absolute HTTP(S) URLs are accepted. The current request host
+    // and APP_URL host are always trusted. Trust is host-only in this version;
+    // scheme and port are not compared.
     'trusted_redirect_hosts' => [],
 ];
 ```

--- a/config/turbo.php
+++ b/config/turbo.php
@@ -39,11 +39,13 @@ return [
     | When a TurboFormRequest fails validation inside a Turbo Frame, the
     | request is redirected back to the frame's source URL. Hosts listed
     | here, plus the current request host and the host from APP_URL, are
-    | always trusted. Anything else falls back to "/" to prevent open
-    | redirects. Accepts bare hosts ("staging.example.com") or full URLs
-    | ("https://staging.example.com"). Useful for reverse proxies, custom
-    | staging domains, or dev setups where `php artisan serve` exposes
-    | 127.0.0.1 while APP_URL points at localhost.
+    | always trusted. Only absolute HTTP(S) URLs and root-relative paths
+    | are eligible redirect sources. Accepts bare hosts
+    | ("staging.example.com") or full URLs ("https://staging.example.com");
+    | only the host is used for trust, so scheme and port are not origin
+    | boundaries in this setting. Useful for reverse proxies, custom staging
+    | domains, or dev setups where `php artisan serve` exposes 127.0.0.1
+    | while APP_URL points at localhost.
     |
     */
 

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,7 @@ parameters:
             - '#Unsafe usage of new static\(\)#'
             - '#Trait .+ is used zero times and is not analysed#'
             -
-                message: '#Call to an undefined method Illuminate\\Http\\Request::(wantsTurboStream|wasFromTurboFrame)\(\)#'
+                message: '#Call to an undefined method Illuminate\\Http\\Request::(wantsTurboStream|wasFromTurboFrame|turboFrameId|turboFrameSource)\(\)#'
                 reportUnmatched: false
             - identifier: argument.type
               message: '#Parameter \#1 \$view of function view expects view-string\|null#'

--- a/src/Http/FrameSourceResolver.php
+++ b/src/Http/FrameSourceResolver.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Emaia\LaravelHotwireTurbo\Http;
+
+use Illuminate\Contracts\Session\Session;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use RuntimeException;
+use ValueError;
+
+final class FrameSourceResolver
+{
+    public function __construct(private Session $session) {}
+
+    /** Resolve an explicit, redirect-safe source URL for the current Turbo Frame request. */
+    public function resolve(Request $request): ?string
+    {
+        if ($this->frameId($request) === null) {
+            return null;
+        }
+
+        return $this->resolveCandidates($request, [
+            ['source' => 'input', 'value' => $request->input('_turbo_frame_src')],
+            ['source' => 'header', 'value' => $request->header('X-Turbo-Frame-Src')],
+        ]);
+    }
+
+    /**
+     * Resolve the validation redirect while retaining the session fallback for compatibility.
+     *
+     * @internal
+     */
+    public function resolveValidationRedirect(Request $request): string
+    {
+        $source = $this->resolveCandidates($request, [
+            ['source' => 'input', 'value' => $request->input('_turbo_frame_src')],
+            ['source' => 'header', 'value' => $request->header('X-Turbo-Frame-Src')],
+        ]);
+
+        if ($source !== null) {
+            return $source;
+        }
+
+        $session = $request->hasSession() ? $request->session() : $this->session;
+        $source = $this->resolveCandidates($request, [
+            ['source' => 'session', 'value' => $session->get('_previous.url')],
+        ]);
+
+        if ($source !== null) {
+            return $source;
+        }
+
+        throw new RuntimeException(
+            'TurboFormRequest: unable to determine a safe frame source URL. '.
+            'Add @turboFrameSrc to the form rendered inside the Turbo Frame.'
+        );
+    }
+
+    /**
+     * @param  list<array{source: string, value: mixed}>  $candidates
+     */
+    private function resolveCandidates(Request $request, array $candidates): ?string
+    {
+        foreach ($candidates as $candidate) {
+            $value = $candidate['value'];
+
+            if ($value === null || $value === '') {
+                continue;
+            }
+
+            $reason = $this->rejectionReason($request, $value);
+
+            if ($reason === null && is_string($value)) {
+                return $value;
+            }
+
+            Log::warning('Rejected Turbo Frame source URL.', [
+                'source' => $candidate['source'],
+                'reason' => $reason,
+                'type' => get_debug_type($value),
+                'length' => is_string($value) ? strlen($value) : null,
+            ]);
+        }
+
+        return null;
+    }
+
+    private function rejectionReason(Request $request, mixed $candidate): ?string
+    {
+        if (! is_string($candidate)) {
+            return 'non_string';
+        }
+
+        if ($candidate === '' || preg_match('/[\x00-\x20\x7F\\\\]/', $candidate) === 1) {
+            return 'forbidden_character';
+        }
+
+        if (preg_match('/%(?![0-9A-Fa-f]{2})/', $candidate) === 1) {
+            return 'malformed_percent_encoding';
+        }
+
+        $parts = $this->parseUrl($candidate);
+
+        if ($parts === null) {
+            return 'malformed_url';
+        }
+
+        if (str_starts_with($candidate, '/')) {
+            if (str_starts_with($candidate, '//')) {
+                return 'protocol_relative';
+            }
+
+            return isset($parts['scheme'], $parts['host']) ? 'malformed_relative_url' : null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if (! in_array($scheme, ['http', 'https'], true)) {
+            return 'unsupported_scheme';
+        }
+
+        if ($host === '') {
+            return 'missing_host';
+        }
+
+        if (isset($parts['user']) || isset($parts['pass'])) {
+            return 'userinfo';
+        }
+
+        $authorityReason = $this->authorityRejectionReason($candidate, $parts);
+
+        if ($authorityReason !== null) {
+            return $authorityReason;
+        }
+
+        return in_array($host, $this->trustedHosts($request), true)
+            ? null
+            : 'untrusted_host';
+    }
+
+    /** @param array<string, int|string> $parts */
+    private function authorityRejectionReason(string $url, array $parts): ?string
+    {
+        $separator = strpos($url, '://');
+
+        if ($separator === false) {
+            return 'malformed_authority';
+        }
+
+        $start = $separator + 3;
+        $authority = substr($url, $start, strcspn($url, '/?#', $start));
+        $host = (string) ($parts['host'] ?? '');
+        $port = isset($parts['port']) ? ':'.$parts['port'] : '';
+
+        if ($authority === '' || str_contains($authority, '%')) {
+            return 'malformed_authority';
+        }
+
+        if (strcasecmp($authority, $host.$port) !== 0) {
+            return 'malformed_authority';
+        }
+
+        if (str_starts_with($host, '[') || str_ends_with($host, ']')) {
+            if (! str_starts_with($host, '[') || ! str_ends_with($host, ']')) {
+                return 'malformed_host';
+            }
+
+            return filter_var(substr($host, 1, -1), FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) === false
+                ? 'malformed_host'
+                : null;
+        }
+
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false) {
+            return null;
+        }
+
+        $hostWithoutTrailingDot = rtrim($host, '.');
+        $lastLabel = strrchr($hostWithoutTrailingDot, '.');
+        $lastLabel = $lastLabel === false ? $hostWithoutTrailingDot : substr($lastLabel, 1);
+
+        if (preg_match('/\A(?:0x[0-9a-f]+|[0-9]+)\z/i', $lastLabel) === 1) {
+            return 'ambiguous_ipv4';
+        }
+
+        return filter_var($host, FILTER_VALIDATE_DOMAIN, FILTER_FLAG_HOSTNAME) === false
+            ? 'malformed_host'
+            : null;
+    }
+
+    /** @return array<string, int|string>|null */
+    private function parseUrl(string $url): ?array
+    {
+        try {
+            $parts = parse_url($url);
+        } catch (ValueError) {
+            return null;
+        }
+
+        return is_array($parts) ? $parts : null;
+    }
+
+    /** @return list<string> */
+    private function trustedHosts(Request $request): array
+    {
+        $hosts = [
+            $request->getHost(),
+            $this->hostFromConfig((string) config('app.url')),
+        ];
+
+        foreach ((array) config('turbo.trusted_redirect_hosts', []) as $entry) {
+            if (is_string($entry)) {
+                $hosts[] = $this->hostFromConfig($entry);
+            }
+        }
+
+        return array_values(array_unique(array_filter(array_map(
+            fn (?string $host): ?string => $host === null ? null : strtolower($host),
+            $hosts,
+        ))));
+    }
+
+    private function hostFromConfig(string $entry): ?string
+    {
+        if ($entry === '') {
+            return null;
+        }
+
+        try {
+            $host = parse_url($entry, PHP_URL_HOST);
+        } catch (ValueError) {
+            return null;
+        }
+
+        if (is_string($host) && $host !== '') {
+            return $host;
+        }
+
+        return str_contains($entry, '://') ? null : $entry;
+    }
+
+    private function frameId(Request $request): ?string
+    {
+        $frame = $request->header('Turbo-Frame');
+
+        if (! is_string($frame) || trim($frame) === '') {
+            return null;
+        }
+
+        return trim($frame);
+    }
+}

--- a/src/Http/Requests/TurboFormRequest.php
+++ b/src/Http/Requests/TurboFormRequest.php
@@ -2,79 +2,18 @@
 
 namespace Emaia\LaravelHotwireTurbo\Http\Requests;
 
+use Emaia\LaravelHotwireTurbo\Http\FrameSourceResolver;
 use Illuminate\Contracts\Validation\Validator;
 use Illuminate\Foundation\Http\FormRequest;
-use Illuminate\Support\Facades\Log;
 
 class TurboFormRequest extends FormRequest
 {
     protected function failedValidation(Validator $validator): void
     {
-        if (request()->wasFromTurboFrame()) {
-            $this->redirect = $this->resolveFrameSourceUrl();
+        if ($this->wasFromTurboFrame()) {
+            $this->redirect = app(FrameSourceResolver::class)->resolveValidationRedirect($this);
         }
 
         parent::failedValidation($validator);
-    }
-
-    private function resolveFrameSourceUrl(): string
-    {
-        return $this->sanitizeRedirectUrl(
-            $this->input('_turbo_frame_src')
-                ?: $this->header('X-Turbo-Frame-Src')
-                ?: $this->getFrameSourceFallback()
-        );
-    }
-
-    private function getFrameSourceFallback(): string
-    {
-        $url = session('_previous.url');
-
-        if ($url) {
-            return $url;
-        }
-
-        throw new \RuntimeException(
-            'TurboFormRequest: unable to determine frame source URL. '.
-            'Add @turboFrameSrc directive to your form inside the Turbo Frame.'
-        );
-    }
-
-    private function sanitizeRedirectUrl(string $url): string
-    {
-        $host = parse_url($url, PHP_URL_HOST);
-
-        // Relative or unparseable URLs are inherently same-origin.
-        if ($host === null || $host === false) {
-            return $url;
-        }
-
-        if (in_array($host, $this->trustedRedirectHosts(), true)) {
-            return $url;
-        }
-
-        Log::warning('TurboFormRequest rejected redirect URL; falling back to "/".', [
-            'url' => $url,
-            'host' => $host,
-            'trusted_hosts' => $this->trustedRedirectHosts(),
-        ]);
-
-        return url('/');
-    }
-
-    private function trustedRedirectHosts(): array
-    {
-        $configured = array_map(
-            fn ($entry) => is_string($entry) ? (parse_url($entry, PHP_URL_HOST) ?: $entry) : null,
-            (array) config('turbo.trusted_redirect_hosts', []),
-        );
-
-        return array_values(array_unique(array_filter(array_merge(
-            [
-                request()->getHost(),
-                parse_url((string) config('app.url'), PHP_URL_HOST),
-            ],
-            $configured,
-        ))));
     }
 }

--- a/src/TurboServiceProvider.php
+++ b/src/TurboServiceProvider.php
@@ -3,6 +3,7 @@
 namespace Emaia\LaravelHotwireTurbo;
 
 use Closure;
+use Emaia\LaravelHotwireTurbo\Http\FrameSourceResolver;
 use Emaia\LaravelHotwireTurbo\Http\Middleware\TurboMiddleware;
 use Emaia\LaravelHotwireTurbo\Models\Name;
 use Emaia\LaravelHotwireTurbo\Response as TurboResponse;
@@ -54,12 +55,20 @@ class TurboServiceProvider extends PackageServiceProvider
             return Str::contains(request()->header('Accept', ''), 'text/vnd.turbo-stream');
         });
 
-        Request::macro('wasFromTurboFrame', function (?string $frame = null): bool {
-            if (! $frame) {
-                return $this->hasHeader('Turbo-Frame');
-            }
+        Request::macro('turboFrameId', function (): ?string {
+            $frame = $this->header('Turbo-Frame');
 
-            return $this->header('Turbo-Frame', null) === $frame;
+            return is_string($frame) && trim($frame) !== '' ? trim($frame) : null;
+        });
+
+        Request::macro('wasFromTurboFrame', function (?string $frame = null): bool {
+            $frameId = $this->turboFrameId();
+
+            return $frame === null ? $frameId !== null : $frameId === $frame;
+        });
+
+        Request::macro('turboFrameSource', function (): ?string {
+            return app(FrameSourceResolver::class)->resolve($this);
         });
 
         Request::macro('turboRequestId', function (): ?string {

--- a/tests/FrameSourceResolverTest.php
+++ b/tests/FrameSourceResolverTest.php
@@ -1,0 +1,229 @@
+<?php
+
+use Emaia\LaravelHotwireTurbo\Http\FrameSourceResolver;
+use Illuminate\Http\Request;
+use Illuminate\Session\ArraySessionHandler;
+use Illuminate\Session\Store;
+use Illuminate\Support\Facades\Log;
+
+function frameSourceRequest(array $input = [], ?string $header = null, bool $fromFrame = true): Request
+{
+    $server = ['HTTP_HOST' => 'localhost'];
+
+    if ($fromFrame) {
+        $server['HTTP_TURBO_FRAME'] = 'modal';
+    }
+
+    if ($header !== null) {
+        $server['HTTP_X_TURBO_FRAME_SRC'] = $header;
+    }
+
+    $request = Request::create('http://localhost/tasks', 'POST', $input, [], [], $server);
+    $request->setLaravelSession(app('session.store'));
+
+    return $request;
+}
+
+it('returns the first valid explicit source without changing its representation', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => '/tasks/create?tag=alpha&tag=beta#errors'],
+        '/tasks/create?from=header',
+    );
+
+    expect(app(FrameSourceResolver::class)->resolve($request))
+        ->toBe('/tasks/create?tag=alpha&tag=beta#errors');
+});
+
+it('accepts absolute HTTP URLs from trusted hosts without rewriting them', function () {
+    config()->set('turbo.trusted_redirect_hosts', ['staging.example.com']);
+    $source = 'HTTPS://STAGING.EXAMPLE.COM:8443/tasks/create?status=pending#form';
+
+    expect(app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $source]),
+    ))->toBe($source);
+});
+
+it('preserves well-formed percent-encoded URL data', function (string $source) {
+    expect(app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $source]),
+    ))->toBe($source);
+})->with([
+    'encoded query data' => '/tasks?pattern=%5Cd%2B&line=%0A',
+    'nested encoding' => '/tasks/%5Carchive?next=%255Cserver',
+    'absolute URL' => 'https://localhost/tasks?pattern=%5Cd%2B#results',
+]);
+
+it('tries the header after an invalid input candidate', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => 'https://evil.example/phishing'],
+        '/tasks/create?status=in_progress',
+    );
+
+    expect(app(FrameSourceResolver::class)->resolve($request))
+        ->toBe('/tasks/create?status=in_progress');
+});
+
+it('ignores non-string input candidates without throwing a type error', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => ['/tasks/create']],
+        '/tasks/create?status=pending',
+    );
+
+    expect(app(FrameSourceResolver::class)->resolve($request))
+        ->toBe('/tasks/create?status=pending');
+});
+
+it('returns null when the request did not come from a Turbo Frame', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => '/tasks/create'],
+        fromFrame: false,
+    );
+
+    expect(app(FrameSourceResolver::class)->resolve($request))->toBeNull();
+});
+
+it('does not expose the session fallback through explicit source resolution', function () {
+    $request = frameSourceRequest();
+    $request->session()->setPreviousUrl('http://localhost/dashboard');
+    $request->headers->set('Referer', 'http://localhost/previous-page');
+
+    expect(app(FrameSourceResolver::class)->resolve($request))->toBeNull();
+});
+
+it('uses a sanitized session URL only for validation redirects', function () {
+    $request = frameSourceRequest();
+    $request->session()->setPreviousUrl('/dashboard?status=pending');
+
+    expect(app(FrameSourceResolver::class)->resolveValidationRedirect($request))
+        ->toBe('/dashboard?status=pending');
+});
+
+it('uses the session attached to the received request', function () {
+    session()->setPreviousUrl('/container-session');
+    $request = frameSourceRequest();
+    $requestSession = new Store('request-session', new ArraySessionHandler(120));
+    $requestSession->setPreviousUrl('/request-session');
+    $request->setLaravelSession($requestSession);
+
+    expect(app(FrameSourceResolver::class)->resolveValidationRedirect($request))
+        ->toBe('/request-session');
+});
+
+it('does not consult a session when an explicit source is valid', function () {
+    $request = Request::create('http://localhost/tasks', 'POST', [
+        '_turbo_frame_src' => '/tasks/create',
+    ], [], [], [
+        'HTTP_HOST' => 'localhost',
+        'HTTP_TURBO_FRAME' => 'modal',
+    ]);
+
+    expect(app(FrameSourceResolver::class)->resolveValidationRedirect($request))
+        ->toBe('/tasks/create');
+});
+
+it('uses the compatibility session when the received request has no session attached', function () {
+    session()->setPreviousUrl('/compatibility-session');
+    $request = Request::create('http://localhost/tasks', 'POST', [], [], [], [
+        'HTTP_HOST' => 'localhost',
+        'HTTP_TURBO_FRAME' => 'modal',
+    ]);
+
+    expect(app(FrameSourceResolver::class)->resolveValidationRedirect($request))
+        ->toBe('/compatibility-session');
+});
+
+it('tries a valid session fallback after invalid explicit candidates', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => 'javascript:alert(1)'],
+        'https://evil.example/phishing',
+    );
+    $request->session()->setPreviousUrl('/dashboard');
+
+    expect(app(FrameSourceResolver::class)->resolveValidationRedirect($request))
+        ->toBe('/dashboard');
+});
+
+it('throws when no safe validation redirect source exists', function () {
+    $request = frameSourceRequest(
+        ['_turbo_frame_src' => 'javascript:alert(1)'],
+        'https://evil.example/phishing',
+    );
+    $request->session()->setPreviousUrl('');
+
+    app(FrameSourceResolver::class)->resolveValidationRedirect($request);
+})->throws(RuntimeException::class, 'unable to determine a safe frame source URL');
+
+it('rejects unsafe and ambiguous redirect candidates', function (mixed $source) {
+    expect(app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $source]),
+    ))->toBeNull();
+})->with([
+    'javascript scheme' => 'javascript:alert(1)',
+    'data scheme' => 'data:text/html,hello',
+    'mailto scheme' => 'mailto:user@example.com',
+    'protocol relative' => '//evil.example/path',
+    'triple slash' => '///evil.example/path',
+    'path relative' => 'tasks/create',
+    'query relative' => '?status=pending',
+    'fragment relative' => '#form',
+    'raw backslash' => '/\\evil.example/path',
+    'backslash scheme separator' => 'http:\\evil.example/path',
+    'missing host' => 'https:///evil.example/path',
+    'leading whitespace' => ' https://evil.example/path',
+    'trusted-looking backslash authority' => 'https://evil.example\\@localhost/path',
+    'userinfo' => 'https://user:secret@localhost/path',
+    'malformed percent escape' => '/tasks?search=%GG',
+    'array input' => [['/tasks/create']],
+    'integer input' => 42,
+    'boolean input' => true,
+]);
+
+it('rejects browser-differential authorities even when their raw host is trusted', function (string $source, string $trustedHost) {
+    config()->set('turbo.trusted_redirect_hosts', [$trustedHost]);
+
+    expect(app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $source]),
+    ))->toBeNull();
+})->with([
+    'percent-encoded host' => ['https://%6cocalhost/tasks', '%6cocalhost'],
+    'invalid bracketed host' => ['https://[localhost]/tasks', '[localhost]'],
+    'octal IPv4' => ['https://0177.0.0.1/tasks', '0177.0.0.1'],
+    'short IPv4' => ['https://127.1/tasks', '127.1'],
+    'integer IPv4' => ['https://2130706433/tasks', '2130706433'],
+    'hexadecimal IPv4' => ['https://0x7f.0.0.1/tasks', '0x7f.0.0.1'],
+    'single hexadecimal IPv4' => ['https://0x7f000001/tasks', '0x7f000001'],
+    'hexadecimal IPv4 final label' => ['https://127.0.0.0x1/tasks', '127.0.0.0x1'],
+    'integer IPv4 with trailing dot' => ['https://2130706433./tasks', '2130706433.'],
+    'empty port' => ['https://localhost:/tasks', 'localhost'],
+]);
+
+it('accepts canonical IP hosts and preserves their ports', function (string $source, string $trustedHost) {
+    config()->set('turbo.trusted_redirect_hosts', [$trustedHost]);
+
+    expect(app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $source]),
+    ))->toBe($source);
+})->with([
+    'IPv4' => ['https://127.0.0.1:8443/tasks', '127.0.0.1'],
+    'IPv6' => ['https://[::1]:8443/tasks', 'https://[::1]'],
+]);
+
+it('does not include rejected URLs or trusted hosts in warning logs', function () {
+    Log::spy();
+    config()->set('turbo.trusted_redirect_hosts', ['private.internal.example']);
+    $secret = 'https://evil.example/path?token=super-secret';
+
+    app(FrameSourceResolver::class)->resolve(
+        frameSourceRequest(['_turbo_frame_src' => $secret]),
+    );
+
+    Log::shouldHaveReceived('warning')->once()->withArgs(function (string $message, array $context) use ($secret): bool {
+        $logged = $message.json_encode($context, JSON_UNESCAPED_SLASHES);
+
+        return ! str_contains($logged, $secret)
+            && ! str_contains($logged, 'super-secret')
+            && ! str_contains($logged, 'private.internal.example')
+            && array_keys($context) === ['source', 'reason', 'type', 'length']
+            && ($context['source'] ?? null) === 'input';
+    });
+});

--- a/tests/RequestMacrosTest.php
+++ b/tests/RequestMacrosTest.php
@@ -39,6 +39,74 @@ it('returns false when no turbo frame header', function () {
     expect(request()->wasFromTurboFrame())->toBeFalse(); // @phpstan-ignore method.notFound
 });
 
+it('returns the current turbo frame id', function () {
+    $this->call('GET', '/', [], [], [], [
+        'HTTP_TURBO_FRAME' => 'modal',
+    ]);
+
+    expect(request()->turboFrameId())->toBe('modal'); // @phpstan-ignore method.notFound
+});
+
+it('returns null when the turbo frame header is empty or absent', function (?string $frame) {
+    $server = $frame === null ? [] : ['HTTP_TURBO_FRAME' => $frame];
+
+    $this->call('GET', '/', [], [], [], $server);
+
+    expect(request()->turboFrameId())->toBeNull(); // @phpstan-ignore method.notFound
+})->with(['absent' => null, 'empty' => '', 'whitespace' => '   ']);
+
+it('compares non-empty turbo frame ids strictly', function () {
+    $this->call('GET', '/', [], [], [], [
+        'HTTP_TURBO_FRAME' => '0',
+    ]);
+
+    expect(request()->turboFrameId())->toBe('0') // @phpstan-ignore method.notFound
+        ->and(request()->wasFromTurboFrame('0'))->toBeTrue() // @phpstan-ignore method.notFound
+        ->and(request()->wasFromTurboFrame(''))->toBeFalse(); // @phpstan-ignore method.notFound
+});
+
+it('trims turbo frame ids before comparing them', function () {
+    $this->call('GET', '/', [], [], [], [
+        'HTTP_TURBO_FRAME' => '  modal  ',
+    ]);
+
+    expect(request()->turboFrameId())->toBe('modal') // @phpstan-ignore method.notFound
+        ->and(request()->wasFromTurboFrame('modal'))->toBeTrue(); // @phpstan-ignore method.notFound
+});
+
+it('resolves explicit turbo frame source input through the request macro', function () {
+    $this->call('POST', '/', [
+        '_turbo_frame_src' => '/tasks/create?status=in_progress',
+    ], [], [], [
+        'HTTP_TURBO_FRAME' => 'modal',
+        'HTTP_X_TURBO_FRAME_SRC' => '/tasks/create?from=header',
+    ]);
+
+    expect(request()->turboFrameSource()) // @phpstan-ignore method.notFound
+        ->toBe('/tasks/create?status=in_progress');
+});
+
+it('falls through invalid source input to a valid source header', function () {
+    $this->call('POST', '/', [
+        '_turbo_frame_src' => ['https://evil.example'],
+    ], [], [], [
+        'HTTP_TURBO_FRAME' => 'modal',
+        'HTTP_X_TURBO_FRAME_SRC' => '/tasks/create?from=header',
+    ]);
+
+    expect(request()->turboFrameSource()) // @phpstan-ignore method.notFound
+        ->toBe('/tasks/create?from=header');
+});
+
+it('does not expose a frame source outside Turbo Frame requests', function () {
+    $this->call('POST', '/', [
+        '_turbo_frame_src' => '/tasks/create',
+    ]);
+
+    expect(request()->turboFrameId())->toBeNull() // @phpstan-ignore method.notFound
+        ->and(request()->turboFrameSource())->toBeNull(); // @phpstan-ignore method.notFound
+});
+
 it('reads the turbo request id from the X-Turbo-Request-Id header', function () {
     $this->call('GET', '/', [], [], [], [
         'HTTP_X_TURBO_REQUEST_ID' => 'abc-123',

--- a/tests/TurboFormRequestTest.php
+++ b/tests/TurboFormRequestTest.php
@@ -14,8 +14,25 @@ class ProfileUpdateRequest extends TurboFormRequest
     }
 }
 
+class PreparedFrameProfileUpdateRequest extends TurboFormRequest
+{
+    protected function prepareForValidation(): void
+    {
+        $this->headers->set('Turbo-Frame', 'profile-form');
+    }
+
+    public function rules(): array
+    {
+        return ['name' => 'required'];
+    }
+}
+
 beforeEach(function () {
     Route::post('/profile', function (ProfileUpdateRequest $request) {
+        // Validation failed, never reached
+    });
+
+    Route::post('/prepared-profile', function (PreparedFrameProfileUpdateRequest $request) {
         // Validation failed, never reached
     });
 });
@@ -35,6 +52,38 @@ it('falls back to session previous url when _turbo_frame_src is absent', functio
 
     $response = $this->fromTurboFrame('profile-form')
         ->post('/profile', ['name' => '']);
+
+    $response->assertRedirect('/dashboard');
+});
+
+it('uses X-Turbo-Frame-Src when the explicit input is absent', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->withHeader('X-Turbo-Frame-Src', '/profile?tab=header')
+        ->post('/profile', ['name' => '']);
+
+    $response->assertRedirect('/profile?tab=header');
+});
+
+it('tries the header after an invalid explicit input', function () {
+    $response = $this->fromTurboFrame('profile-form')
+        ->withHeader('X-Turbo-Frame-Src', '/profile?tab=header')
+        ->post('/profile', [
+            'name' => '',
+            '_turbo_frame_src' => ['https://evil.example'],
+        ]);
+
+    $response->assertRedirect('/profile?tab=header');
+});
+
+it('tries the session fallback after invalid explicit sources', function () {
+    session()->setPreviousUrl(url('/dashboard'));
+
+    $response = $this->fromTurboFrame('profile-form')
+        ->withHeader('X-Turbo-Frame-Src', 'javascript:alert(1)')
+        ->post('/profile', [
+            'name' => '',
+            '_turbo_frame_src' => 'https://evil.example/phishing',
+        ]);
 
     $response->assertRedirect('/dashboard');
 });
@@ -60,20 +109,33 @@ it('accepts relative URL in _turbo_frame_src', function () {
     $response->assertRedirect('/profile?tab=settings');
 });
 
-it('rejects external URL in _turbo_frame_src to prevent open redirect', function () {
-    $response = $this->fromTurboFrame('profile-form')
+it('throws when every provided source is invalid', function () {
+    $this->withoutExceptionHandling();
+    session()->setPreviousUrl('');
+
+    $this->expectException(RuntimeException::class);
+
+    $this->fromTurboFrame('profile-form')
+        ->withHeader('X-Turbo-Frame-Src', 'javascript:alert(1)')
         ->post('/profile', [
             'name' => '',
             '_turbo_frame_src' => 'https://evil.com/phishing',
         ]);
-
-    $response->assertRedirect('/');
 });
 
 it('does not alter redirect for non-turbo-frame requests', function () {
     $response = $this->post('/profile', ['name' => '']);
 
     $response->assertRedirect('/');
+});
+
+it('uses the prepared FormRequest to detect the frame request', function () {
+    $response = $this->post('/prepared-profile', [
+        'name' => '',
+        '_turbo_frame_src' => '/prepared-profile',
+    ]);
+
+    $response->assertRedirect('/prepared-profile');
 });
 
 it('trusts the current request host when it differs from APP_URL host', function () {


### PR DESCRIPTION
## Summary

- Expose `turboFrameId()` and `turboFrameSource()` request macros for explicit frame context.
- Centralize input, header and compatibility-session redirect resolution in `FrameSourceResolver`.
- Reject unsafe and browser-ambiguous redirect authorities while preserving accepted URLs byte-for-byte.
- Document candidate priority, trusted-host semantics, fragment limits and the explicit failure contract.

## Test plan

- [x] `composer format`
- [x] `composer analyse`
- [x] `composer test` - 284/284 passing (501 assertions)
- [x] Manual smoke: submit an invalid form inside a lazy Turbo Frame and confirm validation redirects to the frame source with the form still visible.
- [x] Manual smoke: tamper with `_turbo_frame_src` and `X-Turbo-Frame-Src` using external schemes, backslashes and ambiguous numeric hosts; confirm each candidate is rejected or falls through safely.